### PR TITLE
The `:replace-deps` arg has replaced `:extra-deps` for many tools

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -266,11 +266,11 @@
 
   ;; clojure -M:lib/java11-source
   :lib/java8-source
-  {:replace-deps
+  {:extra-deps
    {openjdk/java-sources {:local/root "/usr/lib/jvm/openjdk-8/lib/src.zip"}}}
 
   :lib/java11-source
-  {:replace-deps
+  {:extra-deps
    {openjdk/java-sources {:local/root "/usr/lib/jvm/openjdk-11/lib/src.zip"}}}
 
   ;; End of: Java Sources

--- a/deps.edn
+++ b/deps.edn
@@ -610,7 +610,7 @@
   ;; https://github.com/jonase/eastwood#running-eastwood-in-a-repl
 
   :lint/eastwood
-  {:replace-deps {jonase/eastwood {:mvn/version "RELEASE"}}
+  {:extra-deps {jonase/eastwood {:mvn/version "RELEASE"}}
    :main-opts  ["-m" "eastwood.lint"
                 "{:source-paths,[\"src\"],:test-paths,[\"test\"]}"]}
 

--- a/deps.edn
+++ b/deps.edn
@@ -100,14 +100,14 @@
   ;; clojure -X:project/new :template luminus :name practicalli/full-stack-app +http-kit +h2 +reagent +auth
 
   :project/new
-  {:extra-deps {seancorfield/clj-new {:mvn/version "1.1.226"}}
+  {:replace-deps {seancorfield/clj-new {:mvn/version "1.1.226"}}
    :exec-fn    clj-new/create
    :exec-args  {:template lib :name practicalli/playground}
    :main-opts  ["-m" "clj-new.create"]}
 
   ;; ALPHA status: Add 'something' to existing project (subject to change)
   :project/add
-  {:extra-deps {seancorfield/clj-new {:mvn/version "1.1.226"}}
+  {:replace-deps {seancorfield/clj-new {:mvn/version "1.1.226"}}
    :exec-fn    clj-new/generate
    :main-opts  ["-m" "clj-new.generate"]}
 
@@ -151,14 +151,14 @@
   ;; - update library versions in this deps.edn file:
   ;; cd ~/.clojure && clojure -M:project/outdated
   :project/outdated
-  {:extra-deps {antq/antq {:mvn/version "RELEASE"}}
+  {:replace-deps {antq/antq {:mvn/version "RELEASE"}}
    :main-opts  ["-m" "antq.core"]}
 
 
   ;; The classic project for checking maven based dependencies
   ;; clojure -M:project/outdated-mvn
   :project/outdated-mvn
-  {:extra-deps {deps-ancient/deps-ancient {:mvn/version "RELEASE"}}
+  {:replace-deps {deps-ancient/deps-ancient {:mvn/version "RELEASE"}}
    :main-opts  ["-m" "deps-ancient.deps-ancient"]}
 
   ;; End of: Projects and dependencies
@@ -176,7 +176,7 @@
   ;; clojure -X:project/jar :main-class domain.application
   ;; clojure -X:project/jar :jar '"project-name.jar"' :main-class domain.application
   :project/jar
-  {:extra-deps {seancorfield/depstar {:mvn/version "1.1.126"}}
+  {:replace-deps {seancorfield/depstar {:mvn/version "1.1.126"}}
    :exec-fn    hf.depstar/jar
    :exec-args  {:jar        "project.jar"
                 :aot        true
@@ -186,7 +186,7 @@
   ;; clojure -X:project/uberjar :main-class domain.application
   ;; clojure -X:project/uberjar :jar '"project-name.jar"' :main-class domain.application
   :project/uberjar
-  {:extra-deps {seancorfield/depstar {:mvn/version "1.1.126"}}
+  {:replace-deps {seancorfield/depstar {:mvn/version "1.1.126"}}
    :exec-fn    hf.depstar/uberjar
    :exec-args  {:jar        "uber.jar"
                 :aot        true
@@ -198,7 +198,7 @@
   ;; "--target" "target/cdeps-0.1.0.jar" in `:main-opts` to specify output file
 
   :project/uberdeps
-  {:extra-deps {uberdeps/uberdeps {:mvn/version "1.0.2"}}
+  {:replace-deps {uberdeps/uberdeps {:mvn/version "1.0.2"}}
    :main-opts  ["-m" "uberdeps.uberjar"]}
 
   ;; Packaging libraries and applications
@@ -225,12 +225,12 @@
   ;; Set fully qualified artifact-name and version in project `pom.xml` file
 
   :project/clojars
-  {:extra-deps {deps-deploy/deps-deploy {:mvn/version "RELEASE"}}
+  {:replace-deps {slipset/deps-deploy {:mvn/version "RELEASE"}}
    :main-opts  ["-m" "deps-deploy.deps-deploy"
                 "deploy"]}
 
   :project/clojars-signed
-  {:extra-deps {deps-deploy/deps-deploy {:mvn/version "RELEASE"}}
+  {:replace-deps {slipset/deps-deploy {:mvn/version "RELEASE"}}
    :main-opts  ["-m" "deps-deploy.deps-deploy"
                 "deploy"
                 :true]}
@@ -266,11 +266,11 @@
 
   ;; clojure -M:lib/java11-source
   :lib/java8-source
-  {:extra-deps
+  {:replace-deps
    {openjdk/java-sources {:local/root "/usr/lib/jvm/openjdk-8/lib/src.zip"}}}
 
   :lib/java11-source
-  {:extra-deps
+  {:replace-deps
    {openjdk/java-sources {:local/root "/usr/lib/jvm/openjdk-11/lib/src.zip"}}}
 
   ;; End of: Java Sources
@@ -610,7 +610,7 @@
   ;; https://github.com/jonase/eastwood#running-eastwood-in-a-repl
 
   :lint/eastwood
-  {:extra-deps {jonase/eastwood {:mvn/version "RELEASE"}}
+  {:replace-deps {jonase/eastwood {:mvn/version "RELEASE"}}
    :main-opts  ["-m" "eastwood.lint"
                 "{:source-paths,[\"src\"],:test-paths,[\"test\"]}"]}
 
@@ -619,7 +619,7 @@
   ;; https://github.com/jonase/kibit/issues/221
 
   :lint/idiom
-  {:extra-deps {tvaughan/kibit-runner {:mvn/version "1.0.1"}}
+  {:replace-deps {tvaughan/kibit-runner {:mvn/version "1.0.1"}}
    :main-opts  ["-m" "kibit-runner.cmdline"]}
 
   ;; End of Linting/ static analysis


### PR DESCRIPTION
When the runtime environment of the project is not required,
`:replace-deps` is the recommended argument.

https://clojure.org/reference/deps_and_cli#_replace_project_environment_tool