### PR TITLE
Add synthetic groupId to refactor-nrepl

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -408,7 +408,7 @@
 
   :middleware/cider-clj-refactor
   {:extra-deps {nrepl/nrepl       {:mvn/version "0.8.2"}
-                refactor-nrepl    {:mvn/version "2.5.0"}
+                refactor-nrepl/refactor-nrepl    {:mvn/version "2.5.0"}
                 cider/cider-nrepl {:mvn/version "0.25.3"}}
    :main-opts  ["-m" "nrepl.cmdline"
                 "--middleware" "[refactor-nrepl.middleware/wrap-refactor,cider.nrepl/cider-middleware]"]}


### PR DESCRIPTION
The `refector-nrepl` dependency should have a synthetic groupId --at least to cut down on noise when `clojure` starts up.