### PR TITLE
Bump reveal to .154

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -408,13 +408,13 @@
   ;; clojure -M:inspect/reveal:rebel -J-Dvlaaad.reveal.prefs='{:theme :light :font-family "Ubuntu Mono" :font-size 32}'
 
   :inspect/reveal
-  {:extra-deps {vlaaad/reveal {:mvn/version "1.0.130"}}
+  {:extra-deps {vlaaad/reveal {:mvn/version "1.0.154"}}
    :ns-default vlaaad.reveal
    :exec-fn    repl
    :main-opts  ["-m" "vlaaad.reveal" "repl"]}
 
   :inspect/reveal-light
-  {:extra-deps {vlaaad/reveal {:mvn/version "1.0.130"}}
+  {:extra-deps {vlaaad/reveal {:mvn/version "1.0.154"}}
    :ns-default vlaaad.reveal
    :exec-fn    repl
    :jvm-opts   ["-Dvlaaad.reveal.prefs={:theme,:light,:font-family,\"https://ff.static.1001fonts.net/u/b/ubuntu.mono.ttf\",:font-size,32}"]
@@ -428,7 +428,7 @@
   ;; Reveal REPL with nrepl server, connect to from a Clojure aware editor
   ;; clj -M:inspect/reveal-nrepl
   :inspect/reveal-nrepl
-  {:extra-deps {vlaaad/reveal {:mvn/version "1.0.130"}
+  {:extra-deps {vlaaad/reveal {:mvn/version "1.0.154"}
                 nrepl/nrepl   {:mvn/version "0.8.2"}}
    :main-opts  ["-m" "nrepl.cmdline"
                 "--middleware" "[vlaaad.reveal.nrepl/middleware]"]}


### PR DESCRIPTION
hi John,
  when trying your config, I found a compile error when trying to use `inspect/reveal-nrepl` (though for some reason, `inspect/reveal` worked just fine). It seems like the version of reveal currently in the config is outdated, and bumping to the latest reveal solves this issue.

Thanks for this nice config!