### PR TITLE
Add :security/nvd alias

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1037,7 +1037,8 @@
   ;; Security
 
   ;; https://github.com/rm-hull/nvd-clojure
-  ;; check all the jars in the classpath for known security vulnerabilities using the National Vulnerability Database:w
+  ;; check all the jars in the classpath for known security vulnerabilities using the
+  ;; National Vulnerability Database
   :security/nvd 
   {:extra-deps {nvd-clojure/nvd-clojure {:mvn/version "1.9.0"}} 
    :main-opts ["-m" "nvd.task.check"]}

--- a/deps.edn
+++ b/deps.edn
@@ -1033,7 +1033,17 @@
   ;; End of Services
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+  ;; Security
 
+  ;; https://github.com/rm-hull/nvd-clojure
+  ;; check all the jars in the classpath for known security vulnerabilities using the National Vulnerability Database:w
+  :security/nvd 
+  {:extra-deps {nvd-clojure/nvd-clojure {:mvn/version "1.9.0"}} 
+   :main-opts ["-m" "nvd.task.check"]}
+  
+  ;; End of Security
+  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
   ;; Deprecated


### PR DESCRIPTION
This adds the `:security/nvd` alias (and a new Security section) to  `deps.edn`.

See https://github.com/rm-hull/nvd-clojure.