### PR TITLE
Add :lint/cljfmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,8 @@ Path to project.jar can also be set in alias to simplify the Clojure command.
 
 ## Formatting
 
-* `:format/zprint filename` - format clojure code and Edn data structures in the given file
+* `:format/zprint filename` - format clojure code and Edn data structures in the given file using zpring
+* `:format/cljfmt [check|fix] filename` - format clojure code and Edn data structures in the given file(s) using cljfmt
 
 
 ## Java Sources

--- a/deps.edn
+++ b/deps.edn
@@ -912,6 +912,12 @@
    :replace-deps  {tvaughan/kibit-runner {:mvn/version "1.0.1"}}
    :main-opts     ["-m" "kibit-runner.cmdline"]}
 
+  ;; cljfmt - show/fix Clojure formatting issues
+  ;; https://github.com/weavejester/cljfmt
+  :lint/cljfmt
+  {:extra-deps {cljfmt/cljfmt {:mvn/version "0.8.0"}}
+   :main-opts ["-m" "cljfmt.main"]}
+
   ;; End of Linting/ static analysis
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/deps.edn
+++ b/deps.edn
@@ -482,13 +482,20 @@
   {:extra-deps {zprint/zprint {:mvn/version "1.1.2"}}
    :main-opts  ["-m" "zprint.main"]}
 
-  ;; cljfmt - show/fix Clojure formatting issues
+  ;; check and fix Clojure formatting with cljfmt:
   ;; https://github.com/weavejester/cljfmt
-  :format/cljfmt
-  {:extra-deps {cljfmt/cljfmt {:mvn/version "0.8.0"}}
-   :main-opts ["-m" "cljfmt.main"]}
 
-  ;; End of: Data manipulation tools
+  ;; cljfmt-check - check/report formatting issues
+  :format/cljfmt-check
+  {:extra-deps {cljfmt/cljfmt {:mvn/version "0.8.0"}}
+   :main-opts ["-m" "cljfmt.main" "check"]}
+
+  ;; cljfmt-check - check/report formatting issues
+  :format/cljfmt-fix
+  {:extra-deps {cljfmt/cljfmt {:mvn/version "0.8.0"}}
+   :main-opts ["-m" "cljfmt.main" "fix"]}
+
+  ;; End of: Formatting tools
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 

--- a/deps.edn
+++ b/deps.edn
@@ -482,6 +482,12 @@
   {:extra-deps {zprint/zprint {:mvn/version "1.1.2"}}
    :main-opts  ["-m" "zprint.main"]}
 
+  ;; cljfmt - show/fix Clojure formatting issues
+  ;; https://github.com/weavejester/cljfmt
+  :format/cljfmt
+  {:extra-deps {cljfmt/cljfmt {:mvn/version "0.8.0"}}
+   :main-opts ["-m" "cljfmt.main"]}
+
   ;; End of: Data manipulation tools
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -911,12 +917,6 @@
   {:replace-paths []
    :replace-deps  {tvaughan/kibit-runner {:mvn/version "1.0.1"}}
    :main-opts     ["-m" "kibit-runner.cmdline"]}
-
-  ;; cljfmt - show/fix Clojure formatting issues
-  ;; https://github.com/weavejester/cljfmt
-  :lint/cljfmt
-  {:extra-deps {cljfmt/cljfmt {:mvn/version "0.8.0"}}
-   :main-opts ["-m" "cljfmt.main"]}
 
   ;; End of Linting/ static analysis
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Another quick one, adds the `:lint/cljfmt` target to find/fix formatting issues.