### PR TITLE
Let Eastwood source paths be inferred

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -901,15 +901,17 @@
   ;; https://github.com/borkdude/clj-kondo/
   :lint/clj-kondo
   {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2021.12.16"}}
-   :main-opts  ["-m" "clj-kondo.main" "--lint" "src"]}
+   :main-opts  ["-m" "clj-kondo.main" "--lint" "src" "test"]}
 
 
   ;; Eastwood - classic lint tool
   ;; https://github.com/jonase/eastwood#running-eastwood-in-a-repl
   :lint/eastwood
   {:extra-deps {jonase/eastwood {:mvn/version "1.0.0"}}
-   :main-opts  ["-m" "eastwood.lint"
-                "{:source-paths,[\"src\"],:test-paths,[\"test\"]}"]}
+   ;; NOTE: source/test paths are accurately inferred, particularly for deps.edn projects,
+   ;; so typically you never have to set them up explicitly.
+   ;; Leaving them for inference is recommended, otherwise a fixed list can get out of date and lint fewer dirs than due.
+   :main-opts  ["-m" "eastwood.lint"]}
 
 
   ;; kibit - suggest idiomatic use of Clojure

--- a/deps.edn
+++ b/deps.edn
@@ -901,16 +901,13 @@
   ;; https://github.com/borkdude/clj-kondo/
   :lint/clj-kondo
   {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2021.12.16"}}
-   :main-opts  ["-m" "clj-kondo.main" "--lint" "src" "test"]}
+   :main-opts  ["-m" "clj-kondo.main" "--lint" "src"]}
 
 
-  ;; Eastwood - classic lint tool
-  ;; https://github.com/jonase/eastwood#running-eastwood-in-a-repl
+  ;; Eastwood - lint tool based on tools.analyzer.jvm
   :lint/eastwood
   {:extra-deps {jonase/eastwood {:mvn/version "1.0.0"}}
-   ;; NOTE: source/test paths are accurately inferred, particularly for deps.edn projects,
-   ;; so typically you never have to set them up explicitly.
-   ;; Leaving them for inference is recommended, otherwise a fixed list can get out of date and lint fewer dirs than due.
+   ;; Eastwood accurately infers source/test paths, so they are best left unspecified:
    :main-opts  ["-m" "eastwood.lint"]}
 
 


### PR DESCRIPTION
* Let Eastwood source paths be inferred
  * Rationale explained inline
* clj-kondo: also lint `"test"`
  * seems a safer default?