### PR TITLE
Remove the recently added nvd alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -673,7 +673,7 @@ Web servers and other standalone services run with Clojure CLI
 
 | Command                                          | Description                                                        |
 |--------------------------------------------------|--------------------------------------------------------------------|
-| `clojure -M:security/nvd "" "$(clojure -Spath)"` | check all jar files on the class path for security vulnerabilities |
+| `clojure -T:security/nvd "" "$(clojure -Spath)"` | check all jar files on the class path for security vulnerabilities |
 
 > The first "" is required argument and can contain a filename to a json file of additional configuration.  The second argument, `"$(clojure -Spath)"`, passes the project classpath to be analysed as a string.
 

--- a/deps.edn
+++ b/deps.edn
@@ -1071,10 +1071,11 @@
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
   ;; Security
 
+  ;; DEPRECATED
   ;; https://github.com/rm-hull/nvd-clojure
   ;; check all the jars in the classpath for known security vulnerabilities using the
   ;; National Vulnerability Database
-  ;; clojure -M:security/nvd "" "$(clojure -Spath)"
+  ;; clojure -T:security/nvd "" "$(clojure -Spath)"
   :security/nvd
   {:extra-deps {nvd-clojure/nvd-clojure {:mvn/version "1.9.0"}}
    :main-opts ["-m" "nvd.task.check"]}


### PR DESCRIPTION
See #31 for reasons and discussion.

This PR completely removes the alias and the documentation.  _EDIT: refactored to mark the `:security/nvd` alias as deprecated as there is potential for false positives from the clojure-nvd library being included on the classpath_