### PR TITLE
github action: specify linters and regex for path to lint

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -30,6 +30,11 @@ jobs:
       - name: Lint everything
         uses: github/super-linter/slim@v4
         env:
+          ## Define Linters to run (others set to false)
+          VALIDATE_YAML: true
+          VALIDATE_MARKDOWN: true
+          VALIDATE_CLOJURE: true
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: live
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FILTER_REGEX_INCLUDE: .*/.*


### PR DESCRIPTION
Env Vars `VALIDATE_` language name specified will run, any languages not
specified are disabled

Regex should include the root directory and be passed to the clj-kondo command
hopefully