### PR TITLE
github-actions: mega-linter for markdown, yaml and deps.edn

### DIFF
--- a/.github/workflows/manual-mega-linter.yaml
+++ b/.github/workflows/manual-mega-linter.yaml
@@ -1,0 +1,40 @@
+# MegaLinter GitHub Action configuration file
+# More info at https://megalinter.github.io
+# All variables described in https://megalinter.github.io/configuration/
+
+name: MegaLinter
+'on':
+  push: null
+  pull_request:
+    branches:
+      - live
+concurrency:
+  group: '${{ github.ref }}-${{ github.workflow }}'
+  cancel-in-progress: true
+jobs:
+  build:
+    name: MegaLinter
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          token: '${{ secrets.PAT || secrets.GITHUB_TOKEN }}'
+          fetch-depth: 0
+      - name: MegaLinter
+        id: ml
+        uses: megalinter/megalinter@v5
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}' # report individual linter status
+          # Validate all source when push on main, else just the git diff with live.
+          VALIDATE_ALL_CODEBASE: >-
+            ${{ github.event_name == 'push' && github.ref == 'refs/heads/live'}}
+
+          # Specific linters to run
+          VALIDATE_YAML: true
+          VALIDATE_MARKDOWN: true
+          VALIDATE_CLOJURE: true
+          CLOJURE_CLJ_KONDO_ARGUMENTS: '--lint deps.edn'
+
+          # ADD CUSTOM ENV VARIABLES OR DEFINE IN A FILE .mega-linter.yml AT ROOT OF REPOSITORY
+          # DISABLE: COPYPASTE,SPELL # Uncomment to disable copy-paste and spell checks


### PR DESCRIPTION
Created github actions workflow from mega-linter example, removing unwanted sections

https://raw.githubusercontent.com/nvuillam/mega-linter/master/TEMPLATES/mega-linter.yml

Added specific linters from super-linter configuration

The node.js assisted install tool failed part way through and did not generate a GitHub actions worflow file