### PR TITLE
Update comments referencing `:project/outdated`

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -64,7 +64,7 @@
   {:extra-deps {nrepl/nrepl {:mvn/version "0.9.0"}}}
 
   ;; alpha state software as API has not been finalized however the code works reliably
-  ;; Latest commit on add-lib3 branch, don't update with :project/outdated
+  ;; Latest commit on add-lib3 branch, don't update with :search/outdated
   ;; Set logging implementation to no-operation
   :lib/hotload
   {:extra-deps {org.clojure/tools.deps.alpha {:git/url "https://github.com/clojure/tools.deps.alpha"
@@ -1113,7 +1113,7 @@
 
   :alpha/hotload-socket
   {:extra-deps {org.clojure/tools.deps.alpha
-                ;; Latest commit on add-lib3 branch, don't update with :project/outdated
+                ;; Latest commit on add-lib3 branch, don't update with :search/outdated
                 {:git/url "https://github.com/clojure/tools.deps.alpha"
                  :sha     "e4fb92eef724fa39e29b39cc2b1a850567d490dd"}
                 ;; Set logging implementation to no-operation


### PR DESCRIPTION
Fixes #54