### PR TITLE
Refactor aliases to simplify config

### DIFF
--- a/.github/linters/markdown-lint.yml
+++ b/.github/linters/markdown-lint.yml
@@ -25,7 +25,7 @@ MD013:
 MD026:
   punctuation: ".,;:!。，；:"  # List of not allowed
 MD029: false                  # Ordered list item prefix
-MD033: true                   # Allow inline HTML
+MD033: false                  # No inline HTML
 MD034: false                  # no bare urls
 MD036: false                  # Emphasis used instead of a heading
 MD041: false                  # first line heading should be top level heading

--- a/.github/linters/mega-linter.yml
+++ b/.github/linters/mega-linter.yml
@@ -1,0 +1,65 @@
+---
+# Configuration file for MegaLinter
+#
+# General configuration:
+# https://oxsecurity.github.io/megalinter/configuration/
+#
+# Specfic Linters:
+# https://oxsecurity.github.io/megalinter/latest/supported-linters/
+
+# ------------------------
+# Linters
+
+# ENABLE specific linters, all other linters automatically disabled
+ENABLE:
+  - MAKEFILE
+  - MARKDOWN
+  - YAML
+  # - REPOSITORY
+
+# Linter specific configuration
+
+# MARKDOWN_MARKDOWN_LINK_CHECK_CONFIG_FILE: ".github/linters/markdown-link-check.json"
+MARKDOWN_MARKDOWNLINT_CONFIG_FILE: ".github/linters/markdown-lint.yml"
+# YAML_PRETTIER_FILTER_REGEX_EXCLUDE: (docs/)
+# YAML_YAMLLINT_FILTER_REGEX_EXCLUDE: (docs/)
+
+# Explicitly disable linters to ensure they are never run
+DISABLE:
+  - COPYPASTE # checks for excessive copy-pastes
+  - SPELL # spell checking - often creates many false positives
+  - CSS #
+
+# Disable linter features
+DISABLE_LINTERS:
+  - REPOSITORY_DEVSKIM # unnecessary URL TLS checks
+  - REPOSITORY_CHECKOV # fails on root user in Dockerfile
+  - REPOSITORY_SECRETLINT
+# ------------------------
+
+# ------------------------
+# Fix Errors
+
+# Automatically update files with corrections
+# APPLY_FIXES: all # all, none, or list of linter keys
+# ------------------------
+
+# ------------------------
+# Reporting
+
+# Activate sources reporter
+UPDATED_SOURCES_REPORTER: false
+
+# Show Linter timings in summary table at end of run
+SHOW_ELAPSED_TIME: true
+
+# Upload reports to file.io
+FILEIO_REPORTER: false
+# ------------------------
+
+# ------------------------
+# Over-ride errors
+
+# detect errors but do not block CI passing
+# DISABLE_ERRORS: true
+# ------------------------

--- a/.github/linters/mega-linter.yml
+++ b/.github/linters/mega-linter.yml
@@ -4,7 +4,7 @@
 # General configuration:
 # https://oxsecurity.github.io/megalinter/configuration/
 #
-# Specfic Linters:
+# Specific Linters:
 # https://oxsecurity.github.io/megalinter/latest/supported-linters/
 
 # ------------------------

--- a/.github/workflows/megalinter.yaml
+++ b/.github/workflows/megalinter.yaml
@@ -3,13 +3,13 @@
 # All variables described in https://megalinter.github.io/configuration/
 
 name: MegaLinter
-'on':
+"on":
   push: null
   pull_request:
     branches:
       - live
 concurrency:
-  group: '${{ github.ref }}-${{ github.workflow }}'
+  group: "${{ github.ref }}-${{ github.workflow }}"
   cancel-in-progress: true
 jobs:
   build:
@@ -19,13 +19,13 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
         with:
-          token: '${{ secrets.PAT || secrets.GITHUB_TOKEN }}'
+          token: "${{ secrets.PAT || secrets.GITHUB_TOKEN }}"
           fetch-depth: 0
       - name: MegaLinter
         id: ml
         uses: megalinter/megalinter/flavors/java@v6.15.0 ## latest release of major version
         env:
-          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}' # report individual linter status
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}" # report individual linter status
           # Validate all source when push on main, else just the git diff with live.
           VALIDATE_ALL_CODEBASE: >-
             ${{ github.event_name == 'push' && github.ref == 'refs/heads/live'}}
@@ -35,8 +35,7 @@ jobs:
           # Specific linters to run
           ENABLE: CREDENTIALS,MARKDOWN,GIT,SPELL,YAML,CLOJURE
           SPELL_CSPELL_DISABLE_ERRORS: true
-          MARKDOWN_MARKDOWNLINT_CONFIG_FILE: ".github/linters/.markdown-lint.yml"
-          CLOJURE_CLJ_KONDO_ARGUMENTS: '--lint deps.edn'
-
+          MARKDOWN_MARKDOWNLINT_CONFIG_FILE: ".github/linters/markdown-lint.yml"
+          CLOJURE_CLJ_KONDO_ARGUMENTS: "--lint deps.edn"
           # ADD CUSTOM ENV VARIABLES OR DEFINE IN A FILE .mega-linter.yml AT ROOT OF REPOSITORY
           # DISABLE: COPYPASTE,SPELL # Uncomment to disable copy-paste and spell checks

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -167,14 +167,14 @@
 
 * 2022-03-25
 ** Added
-*** `:lib/hotload` - latest SHA from add-libs branch of `org.clojure/tools.deps.alpha` to support [hotload libraries into a running REPL](https://practical.li/clojure/alternative-tools/clojure-cli/hotload-libraries.html)
+*** `:lib/hotload` - latest SHA from add-libs branch of `org.clojure/tools.deps.alpha` to support [hotload libraries into a running REPL](https://practical.li/clojure/clojure-cli/hotload-libraries/)
 
 
 * 2022-03-22
 ** Added
 *** `:env/dev` - add `dev` directory to class path - e.g. include `dev/user.clj` to [configure REPL starup](https://practical.li/clojure/clojure-cli/projects/configure-repl-startup.html)
 *** `:lib/nrepl` include nrepl as a library
-*** `:lib/hotload` - include `org.clojure/tools.deps.alpha` add-libs commit to [hotload libraries into a running REPL](https://practical.li/clojure/alternative-tools/clojure-cli/hotload-libraries.html)
+*** `:lib/hotload` - include `org.clojure/tools.deps.alpha` add-libs commit to [hotload libraries into a running REPL](https://practical.li/clojure/clojure-cli/hotload-libraries/)
 *** `:lib/tools-ns` - include `org.clojure/tools.namespace` to refresh the current namespace in a running REPL
 *** `:lib/reloaded` - combination of hotload and tools-ns aliases
 *** `:lib/pretty-errors` - highlight important aspects of error stack trace using ANSI formatting

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -4,6 +4,9 @@
 ** Added
 *** `project/create` alias as a simpler and easier to remember alias for [seancorfield/deps-new](https://github.com/seancorfield/deps-new)
 *** #46 `lib/scope-capture` [scope-capture](https://github.com/vvvvalvalval/scope-capture) library to save and restore state to support REPL debugging
+*** #06 `dev/reloaded` & `:repl/reloaded` aliases - provinding common dev and test libraries and paths
+** Changed
+*** #61 removed depricated aliases and those not used, moving to `deps-deprecated.edn` for posterity, updated README describing aliases use
 
 
 * 2022-12-21

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The project `deps.edn` file is merged with the user wide configuration, e.g `$HO
 
 Configuration passed via the command line when running `clojure` or the `clj` wrapper will take precedence over the project and user level configuration if there is duplication, otherwise they are merged.
 
-![Clojure CLI tools deps.edn configuration precedence](https://raw.githubusercontent.com/practicalli/graphic-design/live/clojure/clojure-cli-tools/clojure-cli-tools-deps-edn-configuration-precedence.png)
+![Clojure CLI tools deps.edn configuration precedence](https://raw.githubusercontent.com/practicalli/graphic-design/live/clojure/clojure-cli/clojure-cli-configuration-precedence.png)
 
 See the rest of this readme for examples of how to use each alias this configuration contains.
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,7 @@
 ## Practicalli Clojure CLI Config
 
-The **[Practicalli Clojure book](https://practical.li/clojure)** uses this configuration extensively to help you develop Clojure projects and learn the Clojure language. Initial inspiration taken from [seancorfield/dot-clojure](https://github.com/seancorfield/dot-clojure).
 
-[![License CC By SA 4.0](https://img.shields.io/badge/license-CC%20BY--SA%204.0%20-blueviolet)](http://creativecommons.org/licenses/by-sa/4.0/?ref=chooser-v1)
-[![GitHub Sponsors for practicalli-john](https://img.shields.io/github/sponsors/practicalli-john)](https://github.com/sponsors/practicalli-john)
-[![Quality Checks](https://github.com/practicalli/clojure-deps-edn/actions/workflows/quality-checks.yaml/badge.svg)](https://github.com/practicalli/clojure-deps-edn/actions/workflows/quality-checks.yaml)
-[![MegaLinter](https://github.com/practicalli/clojure-deps-edn/actions/workflows/megalinter.yaml/badge.svg)](https://github.com/practicalli/clojure-deps-edn/actions/workflows/megalinter.yaml)
-
-<p xmlns:cc="http://creativecommons.org/ns#" xmlns:dct="http://purl.org/dc/terms/">
-<a href="http://creativecommons.org/licenses/by-sa/4.0/?ref=chooser-v1" target="_blank" rel="license noopener noreferrer" style="display:inline-block;">
-<img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg?ref=chooser-v1"><img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg?ref=chooser-v1"><img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/by.svg?ref=chooser-v1"></a>
- <a property="dct:title" rel="cc:attributionURL" href="https://github.com/practicalli/clojure-deps-edn">Practicalli Clojure deps.edn</a> by <a rel="cc:attributionURL dct:creator" property="cc:attributionName" href="https://practical.li">Practicalli</a> is licensed under <a href="http://creativecommons.org/licenses/by-sa/4.0/?ref=chooser-v1" target="_blank" rel="license noopener noreferrer" style="display:inline-block;">CC BY-SA 4.0 </a></p>
-
-## User Config extending Clojure CLI
-
-[Practicalli Clojure CLI Config - deps.edn](https://github.com/practicalli/clojure-deps-edn/blob/live/deps.edn) containes alias definitions for a wide range of community libraries and tools to that extend the feautures of Clojure CLI.
+[Practicalli Clojure CLI Config - deps.edn](https://github.com/practicalli/clojure-deps-edn/blob/live/deps.edn) contains alias definitions for a wide range of community libraries and tools to that extend the feautures of Clojure CLI.
 
 Aliases use qualified descriptive names to avoid clashes with project specific aliases, ensuring that the user wide aliases remain available in all projects.
 
@@ -24,16 +11,28 @@ Aliases are used with the `-A`, `-M`, `-T` or `-X` execution options
 
 > [Clojure CLI - Which execution options to use](https://practical.li/blog/posts/clojure-which-execution-option-to-use/)
 
+The **[Practicalli Clojure book](https://practical.li/clojure)** uses this configuration extensively to help you develop Clojure projects and learn the Clojure language. Initial inspiration taken from [seancorfield/dot-clojure](https://github.com/seancorfield/dot-clojure).
 
-## Check and Format code
+[![License CC By SA 4.0](https://img.shields.io/badge/license-CC%20BY--SA%204.0%20-blueviolet)](http://creativecommons.org/licenses/by-sa/4.0/?ref=chooser-v1)
+[![GitHub Sponsors for practicalli-john](https://img.shields.io/github/sponsors/practicalli-john)](https://github.com/sponsors/practicalli-john)
+[![Quality Checks](https://github.com/practicalli/clojure-deps-edn/actions/workflows/quality-checks.yaml/badge.svg)](https://github.com/practicalli/clojure-deps-edn/actions/workflows/quality-checks.yaml)
+[![MegaLinter](https://github.com/practicalli/clojure-deps-edn/actions/workflows/megalinter.yaml/badge.svg)](https://github.com/practicalli/clojure-deps-edn/actions/workflows/megalinter.yaml)
+
+<div style="width:95%; margin:auto;">
+  <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a>
+  Creative Commons Attribution 4.0 ShareAlike License
+</div>
+
+
+## Format Clojure
 
 [cljstyle](https://github.com/greglook/cljstyle) is a format tool for Clojure files that supports the Clojure Style Guide, using the [.cljstyle configuration file](https://github.com/practicalli/clojure-deps-edn/blob/live/.cljstyle)
 
 
-# Contents
+## Contents
 
-* [Installing practicalli/clojure-deps-edn](#install-practicalli-clojure-cli-config)
-* [Updating practicalli/clojure-deps-edn](#updating-practicalli-clojure-cli-config)
+* [Install Practicalli Clojure CLI Config](#install-practicalli-clojure-cli-config)
+* [Updating practicalli/clojure-deps-edn](#update-practicalli-clojure-cli-config)
 * [Common development tasks](#common-development-tasks)
 * [REPL Terminal UI](#repl-terminal-ui) I
   * [Hotload dependencies](#hotload-libraries) I [Remote REPL Connection](#remote-repl-connection) I [Socket REPL](#socket-repl)
@@ -53,7 +52,7 @@ Aliases are used with the `-A`, `-M`, `-T` or `-X` execution options
 * [Library Hosting Services](#library-hosting-services) - maven mirrors, local repositories
 
 
-## Install Practicalli clojure-deps-edn
+## Install Practicalli Clojure CLI Config
 
 [Clojure CLI](https://clojure.org/guides/install_clojure) version **1.11.1.xxxx** or later is recommended. Check the version of Clojure CLI currently installed via:
 
@@ -89,7 +88,7 @@ The `deps.edn` file in the Clojure CLI configuration directory contains all the 
 `:mvn/local-repo` is a top-level key to set the local maven repository location, such as `/home/practicalli/.cache/maven/repository` to follow the XDG specification.  If setting `:mvn/local-repository`, consider moving the contents of `$HOME/.m2/repository` to the new location to avoid downloading currently cached jar files (or use this as an opportunity to clear out the cache).
 
 
-### Updating Practicalli Clojure CLI Config
+### Update Practicalli Clojure CLI Config
 
 The collection of aliases is regularly reviewed and additional alias suggestions and PRs are most welcome.
 
@@ -125,20 +124,20 @@ How to run common tasks for Clojure development.
 * Project aliases should be added to the individual project `deps.edn` file (or may be part of a template).
 * User/Project alias can be defined in both user and project `deps.edn` files (add to project `deps.edn` for Continuous Integration)
 
-| Task                                                   | Command                                                         | Configuration      |
-|--------------------------------------------------------|-----------------------------------------------------------------|--------------------|
-| Create project (clojure exec)                          | `clojure -T:project/new :template app :name practicalli/my-app` | Practicalli        |
-| Run REPL (rebel readline with nrepl server)            | `clojure -M:repl/rebel`                                         | Practicalli        |
-| Run ClojureScript REPL with nREPL (editor support)     | `clojure -M:repl/cljs`                                          | Practicalli        |
-| Download dependencies                                  | `clojure -P`  (followed by optional aliases)                    | Built-in           |
-| Find libraries (Clojars & Maven Central)               | `clojure -M:search/libraries qualified-lib rary-name(s)`        | Practicalli        |
-| Find available versions of a library                   | `clojure -X:deps find-versions :lib domain/library-name`        | Built-in           |
-| Resolve git coord tags to shas and update deps.edn     | `clojure -X:deps git-resolve-tags git-coord-tag`                | Built-in           |
-| Generate image of project dependency graph             | `clojure -T:project/graph-deps`                                 | Practicalli        |
-| Check library dependencies for newer versions          | `clojure -T:search/outdated`                                    | Practicalli        |
-| Run tests / watch for changes                          | `clojure -X:tests/run` / `clojure -X:test/watch`                | Practicalli        |
-| Run the project  (clojure.main)                        | `clojure -M -m domain.main-namespace`                           | Built-in           |
-| Deploy library locally (~/.m2/repository)              | `clojure -X:deps mvn-install :jar '"project.jar"'`              | Built-in           |
+| Task                                               | Command                                                         | Configuration |
+|----------------------------------------------------|-----------------------------------------------------------------|---------------|
+| Create project (clojure exec)                      | `clojure -T:project/new :template app :name practicalli/my-app` | Practicalli   |
+| Run REPL (rebel readline with nrepl server)        | `clojure -M:repl/rebel`                                         | Practicalli   |
+| Run ClojureScript REPL with nREPL (editor support) | `clojure -M:repl/cljs`                                          | Practicalli   |
+| Download dependencies                              | `clojure -P`  (followed by optional aliases)                    | Built-in      |
+| Find libraries (Clojars & Maven Central)           | `clojure -M:search/libraries qualified-lib rary-name(s)`        | Practicalli   |
+| Find available versions of a library               | `clojure -X:deps find-versions :lib domain/library-name`        | Built-in      |
+| Resolve git coord tags to shas and update deps.edn | `clojure -X:deps git-resolve-tags git-coord-tag`                | Built-in      |
+| Generate image of project dependency graph         | `clojure -T:project/graph-deps`                                 | Practicalli   |
+| Check library dependencies for newer versions      | `clojure -T:search/outdated`                                    | Practicalli   |
+| Run tests / watch for changes                      | `clojure -X:tests/run` / `clojure -X:test/watch`                | Practicalli   |
+| Run the project  (clojure.main)                    | `clojure -M -m domain.main-namespace`                           | Built-in      |
+| Deploy library locally (~/.m2/repository)          | `clojure -X:deps mvn-install :jar '"project.jar"'`              | Built-in      |
 
 
 ## REPL terminal UI
@@ -205,7 +204,7 @@ Environment settings and libraries to support REPL driven development
 
 * `:env/dev` - add `dev` directory to class path - e.g. include `dev/user.clj` to [configure REPL startup](https://practical.li/clojure/clojure-cli/repl-startup/)
 * `env/reloaded` - reloaded workflow, `dev` and `test` paths, testing libraries
-* `:lib/hotload` - include `org.clojure/tools.deps.alpha` add-libs commit to [hotload libraries into a running REPL](https://practical.li/clojure/alternative-tools/clojure-cli/hotload-libraries.html)
+* `:lib/hotload` - include `org.clojure/tools.deps.alpha` add-libs commit to [hotload libraries into a running REPL](https://practical.li/clojure/clojure-cli/hotload-libraries/)
 * `:lib/tools-ns` - include `org.clojure/tools.namespace` to refresh the current namespace in a running REPL
 * `:lib/reloaded` - combination of hotload and tools-ns aliases
 * `:lib/pretty-errors` - highlight important aspects of error stack trace using ANSI formatting
@@ -213,21 +212,14 @@ Environment settings and libraries to support REPL driven development
 
 ## Clojure Projects
 
-* Create projects from deps, leiningen and boot templates with [clj-new](https://github.com/seancorfield/clj-new)
+* Create projects
 * Check and update project dependencies
-* Package projects as jar and uberjars
 * Deploy projects locally and to Clojars
 
-### Create new projects from templates
+Create new projects from templates
 
-* `:project/new` - create a new project from a template
-* `:project/deps-new` - simpler alternative to clj-new (good for your own templates)
-
-Create a new project (via clojure.main - classic approach - recommended for Windows to ensure template arguments are parsed correctly)
-
-```shell
-clojure -M:project/new luminus practicalli/full-stack-app +http-kit +h2 +reagent +auth
-```
+* `:project/new` - create a new project from deps, leiningen and boot templates with [clj-new](https://github.com/seancorfield/clj-new)
+* `:project/create` - deps-new, a simpler alternative to clj-new (good for your own templates)
 
 Create a new project (Edn command line arguments - recommended approach - except for Windows)
 
@@ -310,11 +302,11 @@ Deploy a library jar locally  using the built-in `:deps` alias of Clojure CLI or
 * [:deploy/clojars](https://github.com/slipset/deps-deploy) - deploy jar to [clojars.org](https://clojars.org/)
 * [:deploy/clojars-signed](https://github.com/slipset/deps-deploy) - sign and deploy jar to [clojars.org](https://clojars.org/)
 
-| Command                                            | Description                                                              |
-|----------------------------------------------------|--------------------------------------------------------------------------|
+| Command                                            | Description                                                        |
+|----------------------------------------------------|--------------------------------------------------------------------|
 | `clojure -X:deps mvn-install :jar '"project.jar"'` | deploy jar file to local maven repository, i.e. `~/.m2/repository` |
-| `clojure -M:project/clojars project.jar`           | deploy jar file to Clojars                                               |
-| `clojure -M:project/clojars-signed project.jar`    | deploy signed jar file to Clojars                                        |
+| `clojure -M:project/clojars project.jar`           | deploy jar file to Clojars                                         |
+| `clojure -M:project/clojars-signed project.jar`    | deploy signed jar file to Clojars                                  |
 
 Set Clojars username/token in `CLOJARS_USERNAME` and `CLOJARS_PASSWORD` environment variables.
 
@@ -356,7 +348,7 @@ clojure -M:search/libraries --format:merge http-kit
 
 ## Java Sources
 
-Include Java source on the  classpath to [look up Java Class and method definitions, eg. `cider-find-var` in Emacs](https://practical.li/spacemacs/navigating-code/java-definitions.html)
+Include Java source on the  classpath to [look up Java Class and method definitions, eg. `cider-find-var` in Emacs](https://practical.li/spacemacs/navigating-code/java-definitions/)
 
 Requires: Java sources installed locally (e.g. `"/usr/lib/jvm/openjdk-17/lib/src.zip"`)
 
@@ -385,7 +377,7 @@ REPL driven data inspectors and `tap>` sources for visualising data.
 ### [Portal](https://github.com/djblue/portal)
 
 Navigate data in the form of edn, json and transit
-[Practicalli Clojure -data browsers section - portal](https://practical.li/clojure/clojure-cli/data-browsers/portal.html)
+[Practicalli Clojure -data browsers section - portal](https://practical.li/clojure/data-inspector/portal/)
 
 * `inspect/portal-cli` - Clojure CLI (simplest approach)
 * `inspect/portal-web` - Web ClojureScript REPL
@@ -420,7 +412,7 @@ Emacs CIDER has a built in debug tool that requires no dependencies (other than 
 
 * `lib/sayid` -  an omniscient debugger and profiler for Clojure
 
-The `:lib/sayid` alias can be used with `:repl/cider` when using `cider-connect-clj` or added to the `cider-jack-in-clj` command manually, or via a `.dir-locals.el` configuration using `cider-clojure-cli-aliases`. See the [Practicalli Spacemacs project configuration guide](https://practical.li/spacemacs/clojure-projects/project-configuration.html) for examples.
+The `:lib/sayid` alias can be used with `:repl/cider` when using `cider-connect-clj` or added to the `cider-jack-in-clj` command manually, or via a `.dir-locals.el` configuration using `cider-clojure-cli-aliases`. See the [Practicalli Spacemacs project configuration guide](https://practical.li/spacemacs/clojure-development/project-configuration/) for examples.
 
 
 ## Clojure Specification
@@ -430,15 +422,13 @@ Clojure spec, generators and test.check
 * `:lib/spec-test` - generative testing with Clojure test.check
 * `:lib/spec2` - experiment with the next version of Clojure spec - alpha: design may change
 
+
 ## Unit Testing frameworks
 
 Unit test libraries and configuration.  The Clojure standard library includes the `clojure.test` namespace, so no alias is required.
 
 * `:env/test` - add `test` directory to classpath
-* [`:lib/expectations`](https://github.com/clojure-expectations/clojure-test) - `clojure.test` with expectations
-* [`:lib/expectations-classic`](https://github.com/clojure-expectations/expectations) - expectations framework
 
-Include expectations as a development dependency in a project `clojure -M:env/test:lib/expectations`, or on the command line with the cognitect test runner `clojure -M:lib/expectations:test/cognitect`
 
 ## Test runners and Test Coverage tools
 
@@ -446,13 +436,13 @@ Include expectations as a development dependency in a project `clojure -M:env/te
 
 Run unit tests in a project which are defined under the `test` path. See
 
-| Command                            | Description                                                                               |
-|------------------------------------|-------------------------------------------------------------------------------------------|
-| `clojure -X:test/run`              | run tests with the Kaocha comprehensive test runner for Clojure (same as :test/kaocha)    |
-| `clojure -X:test/watch`            | run tests in watch mode using Kaocha test runner for Clojure (same as :test/kaocha-watch) |
-| `clojure -X:test/cognitect`        | Cognitect Clojure test runner                                                             |
-| `clojure -X:test/coverage`         | Cloverage clojure.test coverage report                                                    |
-| `clojure -M:test/cljs`             | ClojureScript test runner (Kaocha)                                                        |
+| Command                     | Description                                                                               |
+|-----------------------------|-------------------------------------------------------------------------------------------|
+| `clojure -X:test/run`       | run tests with the Kaocha comprehensive test runner for Clojure (same as :test/kaocha)    |
+| `clojure -X:test/watch`     | run tests in watch mode using Kaocha test runner for Clojure (same as :test/kaocha-watch) |
+| `clojure -X:test/cognitect` | Cognitect Clojure test runner                                                             |
+| `clojure -X:test/coverage`  | Cloverage clojure.test coverage report                                                    |
+| `clojure -M:test/cljs`      | ClojureScript test runner (Kaocha)                                                        |
 
 `:lib/kaocha` alias adds kaocha as a library to the class path, enabling scripts such as kaocha-runner.el to run Kaocha test runner from Emacs Cider
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-![Practicalli Clojure deps.edn user wide configuration for Clojure projects](https://raw.githubusercontent.com/practicalli/graphic-design/live/banners/practicalli-clojure-deps-edn-banner.png)
+## Practicalli Clojure CLI Config
+
+The **[Practicalli Clojure book](https://practical.li/clojure)** uses this configuration extensively to help you develop Clojure projects and learn the Clojure language. Initial inspiration taken from [seancorfield/dot-clojure](https://github.com/seancorfield/dot-clojure).
 
 [![License CC By SA 4.0](https://img.shields.io/badge/license-CC%20BY--SA%204.0%20-blueviolet)](http://creativecommons.org/licenses/by-sa/4.0/?ref=chooser-v1)
 [![GitHub Sponsors for practicalli-john](https://img.shields.io/github/sponsors/practicalli-john)](https://github.com/sponsors/practicalli-john)
@@ -10,37 +12,45 @@
 <img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg?ref=chooser-v1"><img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg?ref=chooser-v1"><img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/by.svg?ref=chooser-v1"></a>
  <a property="dct:title" rel="cc:attributionURL" href="https://github.com/practicalli/clojure-deps-edn">Practicalli Clojure deps.edn</a> by <a rel="cc:attributionURL dct:creator" property="cc:attributionName" href="https://practical.li">Practicalli</a> is licensed under <a href="http://creativecommons.org/licenses/by-sa/4.0/?ref=chooser-v1" target="_blank" rel="license noopener noreferrer" style="display:inline-block;">CC BY-SA 4.0 </a></p>
 
-## User level configuration for Clojure CLI
+## User Config extending Clojure CLI
 
-[practicalli/clojure-deps-edn](https://github.com/practicalli/clojure-deps-edn) adds community libraries and tools to use with all Clojure CLI projects or as stand-alone tools.  Aliases use qualified descriptive names to avoid clashes with project specific aliases, ensuring that the user wide aliases remain available in all projects.
+[Practicalli Clojure CLI Config - deps.edn](https://github.com/practicalli/clojure-deps-edn/blob/live/deps.edn) containes alias definitions for a wide range of community libraries and tools to that extend the feautures of Clojure CLI.
+
+Aliases use qualified descriptive names to avoid clashes with project specific aliases, ensuring that the user wide aliases remain available in all projects.
 
 Common default arguments are included in an alias via `:exec-args` to minimise the cognitive load required to use aliases.
 
-The **[Practicalli Clojure book](https://practical.li/clojure)** uses this configuration extensively to help you develop Clojure projects and learn the Clojure language. Initial inspiration taken from [seancorfield/dot-clojure](https://github.com/seancorfield/dot-clojure).
+Aliases are used with the `-A`, `-M`, `-T` or `-X` execution options
+
+> [Clojure CLI - Which execution options to use](https://practical.li/blog/posts/clojure-which-execution-option-to-use/)
+
+
+## Check and Format code
+
+[cljstyle](https://github.com/greglook/cljstyle) is a format tool for Clojure files that supports the Clojure Style Guide, using the [.cljstyle configuration file](https://github.com/practicalli/clojure-deps-edn/blob/live/.cljstyle)
+
 
 # Contents
 
-* [Installing practicalli/clojure-deps-edn](#install-practicalli-clojure-deps-edn)
-* [Updating practicalli/clojure-deps-edn](#updating-practicalli-clojure-deps-edn)
+* [Installing practicalli/clojure-deps-edn](#install-practicalli-clojure-cli-config)
+* [Updating practicalli/clojure-deps-edn](#updating-practicalli-clojure-cli-config)
 * [Common development tasks](#common-development-tasks)
-* [Aliases](#aliases)
-  * Running a REPL
-    * [REPL Terminal UI](#repl-terminal-ui) I [REPL with Editor](#repl-with-editor) I [Hotload dependencies](#hotload-libraries-into-a-running-repl) I [Remote REPL Connection](#remote-repl-connection) I [Alternative REPL](#alternative-repl) I [Middleware](#middleware)
-  * [Development Environment](#development-environment)
-  * [Clojure Projects](#clojure-projects)
-    * [Dependencies](#project-dependencies) I [Analysis](#project-analysis) I [Packaging](#project-packaging) I [Deployment](#project-deployment)
+* [REPL Terminal UI](#repl-terminal-ui) I
+  * [Hotload dependencies](#hotload-libraries) I [Remote REPL Connection](#remote-repl-connection) I [Socket REPL](#socket-repl)
+* [Development Environment](#development-environment)
+* [Clojure Projects](#clojure-projects)
+  * [Dependencies](#project-dependencies) I [Analysis](#project-analysis) I [Packaging](#project-packaging) I [Deployment](#project-deployment)
   * [Searching](#searching)
   * [Format](#format-code) I [Lint](#lint-tools)
   * [Java sources](#java-sources)
-  * [Unit Testing](#unit-testing-frameworks)
-    * [Test runners](#test-runners-and-test-coverage-tools) I [Clojure Spec](#clojure-specification) I [Performance](#performance-testing) I [Security](#security)
-  * [Databases](#databases-and-drivers)
-  * [Data Inspectors](#data-inspectors)
-    * [Visualise vars and deps](#visualising-project-vars-and-library-dependencies)
-  * [Debug](#debug-tools)
-  * [Services](#services)
+* [Testing](#unit-testing-frameworks)
+  * [Test runners](#test-runners-and-test-coverage-tools) I [Clojure Spec](#clojure-specification) I [Performance](#performance-testing) I [Security](#security)
+* [Databases](#databases-and-drivers)
+* [Data Inspectors](#data-inspectors)
+  * [Visualise vars and deps](#visualising-project-vars-and-library-dependencies)
+* [Debug](#debug-tools)
+* [Services](#services)
 * [Library Hosting Services](#library-hosting-services) - maven mirrors, local repositories
-
 
 
 ## Install Practicalli clojure-deps-edn
@@ -51,7 +61,7 @@ The **[Practicalli Clojure book](https://practical.li/clojure)** uses this confi
 clojure -Sdescribe
 ```
 
-> [Practicalli guide to installing Clojure](https://practical.li/clojure/clojure-cli/install/clojure-cli.html) has detailed instructions to install Clojure CLI for a specific operating system, or follow the [Clojure.org Getting Started page](https://clojure.org/guides/getting_started).
+> [Practicalli guide to installing Clojure](https://practical.li/clojure/install/clojure-cli/) has detailed instructions to install Clojure CLI for a specific operating system, or follow the [Clojure.org Getting Started page](https://clojure.org/guides/getting_started).
 
 When Clojure CLI runs for the first time a configuration directory is created in `$XDG_CONFIG_HOME/clojure` or `$HOME/.clojure` if [XDG_CONFIG_HOME](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html "FreeDesktop.org specification") not set
 
@@ -76,10 +86,10 @@ The `deps.edn` file in the Clojure CLI configuration directory contains all the 
 
 `$HOME/.m2/repository` is the default location of the local maven repository, the directory where library dependency jar files are cached.
 
-`:mvn/local-repo` is a top-level key to set the local maven repository location, such as `$HOME/.cache/maven/repository` to follow the XDG specification.  If setting `:mvn/local-repository`, consider moving the contents of `$HOME/.m2/repository` to the new location to avoid downloading currently cached jar files (or use this as an opportunity to clear out the cache).
+`:mvn/local-repo` is a top-level key to set the local maven repository location, such as `/home/practicalli/.cache/maven/repository` to follow the XDG specification.  If setting `:mvn/local-repository`, consider moving the contents of `$HOME/.m2/repository` to the new location to avoid downloading currently cached jar files (or use this as an opportunity to clear out the cache).
 
 
-### Updating Practicalli clojure-deps-edn
+### Updating Practicalli Clojure CLI Config
 
 The collection of aliases is regularly reviewed and additional alias suggestions and PRs are most welcome.
 
@@ -93,7 +103,7 @@ clojure -T:search/outdated > outdated.org
 > Pull Requests from `:search/outdated` cannot be accepted unless full testing of every change can be demonstrated
 
 
-## Using Practicalli clojure-deps-edn
+## Using Practicalli Clojure CLI Config
 
 Any directory containing a `deps.edn` file is considered a Clojure project. A `deps.edn` file can contain an empty hash-map, `{}` or hash-map with configuration, usually `:paths` and `:dependencies` and perhaps some `:aliases`.
 
@@ -117,98 +127,48 @@ How to run common tasks for Clojure development.
 
 | Task                                                   | Command                                                         | Configuration      |
 |--------------------------------------------------------|-----------------------------------------------------------------|--------------------|
-| Create project (clojure exec)                          | `clojure -T:project/new :template app :name practicalli/my-app` | User alias         |
-| Run REPL (rebel readline with nrepl server)            | `clojure -M:repl/rebel`                                         | User alias         |
-| Run ClojureScript REPL with nREPL (editor support)     | `clojure -M:repl/cljs-nrepl`                                    | User alias         |
+| Create project (clojure exec)                          | `clojure -T:project/new :template app :name practicalli/my-app` | Practicalli        |
+| Run REPL (rebel readline with nrepl server)            | `clojure -M:repl/rebel`                                         | Practicalli        |
+| Run ClojureScript REPL with nREPL (editor support)     | `clojure -M:repl/cljs`                                          | Practicalli        |
 | Download dependencies                                  | `clojure -P`  (followed by optional aliases)                    | Built-in           |
-| Find libraries (Clojars & Maven Central)               | `clojure -M:search/libraries library-name(s)`                   | User alias         |
+| Find libraries (Clojars & Maven Central)               | `clojure -M:search/libraries qualified-lib rary-name(s)`        | Practicalli        |
 | Find available versions of a library                   | `clojure -X:deps find-versions :lib domain/library-name`        | Built-in           |
 | Resolve git coord tags to shas and update deps.edn     | `clojure -X:deps git-resolve-tags git-coord-tag`                | Built-in           |
-| Generate image of project dependency graph             | `clojure -T:project/graph-deps`                                 | User alias         |
-| Check library dependencies for newer versions          | `clojure -T:search/outdated`                                    | User alias         |
-| Run tests / watch for changes                          | `clojure -X:tests/run` / `clojure -X:test/watch`                | User/Project alias |
+| Generate image of project dependency graph             | `clojure -T:project/graph-deps`                                 | Practicalli        |
+| Check library dependencies for newer versions          | `clojure -T:search/outdated`                                    | Practicalli        |
+| Run tests / watch for changes                          | `clojure -X:tests/run` / `clojure -X:test/watch`                | Practicalli        |
 | Run the project  (clojure.main)                        | `clojure -M -m domain.main-namespace`                           | Built-in           |
-| [Run the project](https://youtu.be/u5VoFpsntXc?t=2166) | `clojure -X:project/run`                                        | Project alias      |
-| Package library                                        | `clojure -X:project/jar`                                        | User/Project alias |
 | Deploy library locally (~/.m2/repository)              | `clojure -X:deps mvn-install :jar '"project.jar"'`              | Built-in           |
-| Package application                                    | `clojure -X:project/uberjar`                                    | User/Project alias |
-
-> Add alias `:project/run` to the deps.edn file in the root of a project:
->
-> `:project/run {:exec-fn domain.namespace/-main}`
->
-> Watch: [Clojure CLI - practicalli/clojure-deps-edn community tools](https://youtu.be/u5VoFpsntXc?t=2166) to see some of these in action
-
-
-# Aliases
-
-Aliases provide additional configuration when running a REPL, an application or to use a community tool.
-
-* add or remove dependencies
-* add or remove directories on the class path
-* define a function or main namespace to run, along with arguments
-
-## Clojure CLI main flag options
-
-| Flag            | Purpose                                                  | Config used                                          |
-|-----------------|----------------------------------------------------------|------------------------------------------------------|
-| `-M`            | Run Clojure project with clojure.main                    | deps, path, `:main-opts` & command line args         |
-| `-P`            | Prepare / dry run (CI servers, Containers)               | deps, path                                           |
-| `-P -M:aliases` | Prepare / dry run including alias deps and paths         | deps, path                                           |
-| `-P -X:aliases` | Prepare / dry run including alias deps and paths         | deps, path                                           |
-| `-X`            | Execute a qualified function, optional default arguments | deps, path, `:exec-fn`, `:exec-args` & :key val args |
-| `-T`            | Run a tool or alias separate from a project classpath    | `:exec-fn`, `:exec-args` & :key val args             |
-| `-J`            | Java Virtual Machine specific options (memory size, etc) |                                                      |
-
-* deps = `:deps`, `:extra-deps` or `replace-deps`
-* path = `:path`, `:extra-paths` or `replace-paths`
 
 
 ## REPL terminal UI
 
-Run an interactive REPL on the command line with the simple REPL UI or [Rebel readline](https://github.com/bhauman/rebel-readline) for a feature rich REPL experience.
+Run an interactive REPL on the command line with the basic built-in REPL UI or [Rebel](https://practical.li/clojure/clojure-cli/repl/) for a feature rich REPL experience.
 
-nREPL server is started by default, so that editors and other command line sessions can connect to the same REPL.
+nREPL server is started for all Clojure repl aliases along with the cider-nrepl middleware, so Clojure editors can connect to the REPL process started on the command line.
 
-See [Middleware aliases](#middleware) to run a headless REPL process without a REPL UI
+| Command                        | Description                                                                        |
+|--------------------------------|------------------------------------------------------------------------------------|
+| `clojure -M:repl/rebel`        | Rebel Rich terminal UI Clojure REPL with nREPL for connecting editors              |
+| `clojure -M:repl/basic`        | Basic terminal UI Clojure REPL with nREPL for connecting editors                   |
+| `clojure -M:repl/reloaded`     | As above with `dev` path, library hotload, namespace reload, Portal data inspector |
+| `clojure -M:repl/cljs`         | Basic terminal UI ClojureScript REPL using Rebel Readline                          |
+| `clojure -M:repl/rebel-cljs`   | Rich terminal UI ClojureScript REPL using Rebel Readline                           |
+| `clojure -M:repl/figwheel`     | Rich terminal UI ClojureScript REPL using Rebel Readline with Figwheel built tool  |
+| `clojure -M:repl/headless`     | REPL without prompt, include nREPL for connecting editors                          |
+| `clojure -M:repl/rebel-remote` | Connect to a remote REPL via nREPL with Rebel Rich terminal UI                     |
+| `clojure -M:repl/remote`       | As above with basic prompt                                                         |
 
-Use the `:env/dev` alias with the :repl aliases to include `dev/` in classpath and [configure REPL startup actions using `dev/user.clj`](https://practical.li/clojure/clojure-cli/projects/configure-repl-startup.html)
+> Use `:env/dev`  with the `:repl/rebel` aliases to include `dev/` in classpath and [configure REPL startup actions using `dev/user.clj`](https://practical.li/clojure/clojure-cli/repl-startup/)
 
-| Command                         | Description                                                                  |
-|---------------------------------|------------------------------------------------------------------------------|
-| `clojure -M:repl/rebel`         | Rich terminal UI Clojure REPL using Rebel Readline                           |
-| `clojure -M:env/dev:repl/rebel` | As above, including `:extra-deps` and `:extra-path` from `:env/dev` alias    |
-| `clojure -M:repl/rebel-cljs`    | Rich terminal UI ClojureScript REPL using Rebel Readline                     |
-| `clojure -M:repl/rebel-reveal`  | Rich terminal UI Clojure REPL using Rebel Readline and Reveal data inspector |
+## Hotload Libraries
 
-`:repl/help` in the Rebel UI for help and available commands.  `:repl/quit` to close the REPL.
+`clojure -M:repl/reloaded` provides [hotloading of libraries in a running REPL process](https://practical.li/clojure/clojure-cli/hotload-libraries/) with the Rebel rich terminal UI.
 
-> [Data Inspectors](#data-inspectors) section defines `:inspect/reveal` alias
-> for a Reveal REPL with visualization, along with other data visualization
-> tools.
+Or use `clj -M:env/reloaded:repl/basic` for a reloaded workflow with a basic terminal REPL prompt.
 
-## REPL with Editor
 
-Run an interactive REPL on the command line with the simple terminal UI, including an nREPL server and Cider libraries to support connections from Clojure editors, e.g. Conjure, CIDER and Calva.
-
-| Command                          | Description                                                                       |
-|----------------------------------|-----------------------------------------------------------------------------------|
-| `clojure -M:repl/nrepl`          | Clojure REPL with nREPL server for editor support                                 |
-| `clojure -M:repl/cljs-nrepl`     | ClojureScript REPL with nREPL for editor support                                  |
-| `clojure -M:repl/cider`          | Clojure REPL with nREPL server and Cider-nrepl                                    |
-| `clojure -M:repl/cider-refactor` | Clojure REPL with nREPL server, Cider-nrepl and clj-refactor                      |
-| `clj -M:repl/reveal-nrepl`       | Clojure REPL with Reveal data visualization and nREPL interactively               |
-| `clj -M:repl/reveal-light-nrepl` | Clojure REPL with Reveal data visualization (light theme) and nREPL interactively |
-
-## Hotload libraries into a running REPL
-
-Use the `:lib/hotload` alias in front of any of the above aliases to enable [hotloading of libraries into a running REPL process](https://practical.li/clojure/alternative-tools/clojure-cli/hotload-libraries.html).
-
-`clojure -M:lib/hotload:repl/rebel` enables hotloading in the REPL terminal UI.
-
-`clojure -M:lib/hotload:env/dev:repl/rebel` enables hotloading, included the dev directory (to auto-load `user.clj`) with a REPL terminal UI.
-
-## Remote REPL connection
+### Remote REPL connection
 
 Connect to the nREPL server of a remote REPL using nREPL connect, using a simple terminal UI
 
@@ -223,13 +183,11 @@ clojure -M:repl/rebel-remote --host hostname --port 12345
 ```
 
 
-## Alternative REPL
+## Socket REPL
 
 Clojure 1.10.x onward can [run a Socket Server](https://clojure.org/reference/repl_and_main#_launching_a_socket_server) for serving a socket-based REPL (Clojure and ClojureScript).
 
 [tubular](https://github.com/mfikes/tubular) is a Socket Server client for Clojure and Clojurescript REPL processes.
-
-PREPL is a REPL with structured output.  See [Cloure socket prepl cookbook](https://oli.me.uk/clojure-socket-prepl-cookbook/) for examples.
 
 | Command                          | Description                                                                     |
 |----------------------------------|---------------------------------------------------------------------------------|
@@ -239,16 +197,14 @@ PREPL is a REPL with structured output.  See [Cloure socket prepl cookbook](http
 | `clojure -M:repl/socket-node`    | ClojureScript REPL using Socket Server on port 55555                            |
 | `clojure -M:repl/socket-browser` | ClojureScript REPL using Socket Server on port 58585                            |
 | `clojure -M:repl/socket-client`  | Socket REPL client on port 50505 ([tubular](https://github.com/mfikes/tubular)) |
-| `clojure -M:repl/prepl`          | Clojure REPL using PREPL Server on port 40404                                   |
-| `clojure -M:repl/prepl-cljs`     | Clojure REPL using PREPL Server on port 44444                                   |
 
 
 ## Development Environment
 
 Environment settings and libraries to support REPL driven development
 
-* `:env/dev` - add `dev` directory to class path - e.g. include `dev/user.clj` to [configure REPL startup](https://practical.li/clojure/clojure-cli/projects/configure-repl-startup.html)
-* `:lib/nrepl` include nrepl as a library
+* `:env/dev` - add `dev` directory to class path - e.g. include `dev/user.clj` to [configure REPL startup](https://practical.li/clojure/clojure-cli/repl-startup/)
+* `env/reloaded` - reloaded workflow, `dev` and `test` paths, testing libraries
 * `:lib/hotload` - include `org.clojure/tools.deps.alpha` add-libs commit to [hotload libraries into a running REPL](https://practical.li/clojure/alternative-tools/clojure-cli/hotload-libraries.html)
 * `:lib/tools-ns` - include `org.clojure/tools.namespace` to refresh the current namespace in a running REPL
 * `:lib/reloaded` - combination of hotload and tools-ns aliases
@@ -343,26 +299,12 @@ clojure -M:project/unused --opts '{:paths ["src" "test"] :report {:format :ignor
 
 ### Project packaging
 
-Build a project archive file for deployment
+[tools.build](https://practical.li/clojure/clojure-cli/projects/tools-build/) is a library for creating scripts to manage packaging the projects to a fine level of control.  Projects start with common tasks for builind a jar or uberjar from the project.
 
-* [:project/jar](https://github.com/seancorfield/depstar) - build jar for deps.edn project
-* [:project/uberjar](https://github.com/seancorfield/depstar) - build uberjars for deps.edn project
-* [:project/uberdeps](https://github.com/tonsky/uberdeps) - uberjar builder
-
-| Command                                                  | Description                                                  |
-|----------------------------------------------------------|--------------------------------------------------------------|
-| `clojure -X:project/jar :main-class domain.app-name`     | package `project.jar` for deps.edn project (publish library) |
-| `clojure -X:project/uberjar :main-class domain.app-name` | package `uber.jar` for deps.edn project (deploy application) |
-
-Additionally specify `:jar` name and if ahead of time compilation should be used (default true)
-c
-```clojure
-clojure -X:project/jar :jar '"practicalli.app.jar"' :aot false :main-class domain.app-name
-```
 
 ### Project Deployment
 
-Deploy a project archive file locally or to Clojars.org
+Deploy a library jar locally  using the built-in `:deps` alias of Clojure CLI or to Clojars.org using [slipset/deps-deploy](https://github.com/slipset/deps-deploy) project.
 
 * [`-X:deps mvn-install`](https://clojure.org/reference/deps_and_cli#_local_maven_install) built-in Clojure CLI alias to deploy a Jar locally in the `~/.m2/repository` directory
 * [:deploy/clojars](https://github.com/slipset/deps-deploy) - deploy jar to [clojars.org](https://clojars.org/)
@@ -418,14 +360,13 @@ Include Java source on the  classpath to [look up Java Class and method definiti
 
 Requires: Java sources installed locally (e.g. `"/usr/lib/jvm/openjdk-17/lib/src.zip"`)
 
-* `:src/java8`
-* `:src/java11`
 * `:src/java17`
 * `:src/clojure`
 
 Use the aliases with either `-A`, `-M` or `-X` execution options on the Clojure command line.
 
 > Clone [clojure/clojure](https://github.com/clojure-expectations/clojure-test) repository. Clojure core Java source code in [src/jvm/clojure/lang/](https://github.com/clojure/clojure/tree/master/src/jvm/clojure/lang "GitHub: Clojure core Java source code")
+
 
 ## Databases and drivers
 
@@ -470,144 +411,6 @@ Navigate data in the form of edn, json and transit
 
 `(portal/close)` to close the inspector window.
 
-### Reveal data inspector and visualization tool
-
-[Reveal](https://vlaaad.github.io/reveal/) - run a Terminal REPL with data visualisation or connect with nREPL, socket or prepl connection and use from
-any [Clojure aware editor]([Clojure aware editors](https://practical.li/clojure/clojure-editors/)).
-
-Reveal can also used as a `tap>` source for more powerful manual debugging.
-
-* `:inspect/reveal` - simple terminal UI Clojure REPL with Reveal data visualisation UI.
-* `:inspect/reveal-light` - as above with light theme and 32 point Ubuntu Mono font
-* `:inspect/reveal-nrepl` - as `:inspect/reveal` with nREPL server for [Clojure aware editors](https://practical.li/clojure/clojure-editors/)
-* `:inspec/reveal-light-nrepl` - as above with light theme and 32 point Ubuntu Mono font
-* `:inspect/reveal-nrepl-cider` - as `:inspect-nrepl` with Clojure nREPL support for Emacs Cider
-* `:inspec/reveal-light-cider` - as above with light theme and 32 point Ubuntu Mono font
-
-| Command                                      | Description                                                                        |
-|----------------------------------------------|------------------------------------------------------------------------------------|
-| `clojure -X:inspect/reveal`                  | start a Reveal repl with data visualization window (cloure.main)                   |
-| `clojure -X:inspect/reveal-light`            | as above with light theme and large font                                           |
-| `clojure -X:inspect/reveal`                  | start a Reveal repl with data visualization window (clojure exec)                  |
-| `clojure -X:inspect/reveal-light`            | as above with light theme and large font                                           |
-| `clojure -M:inspect/reveal-nrepl`            | Start nrepl server to use Cider / Calva editors with reveal                        |
-| `clojure -M:inspect/reveal-light-nrepl`      | as above with light theme and large font                                           |
-| `clojure -M:inspect/reveal-nrepl`            | Start nrepl server to use Cider / Calva editors with reveal                        |
-| `clojure -M:inspect/reveal-light-nrepl`      | as above with light theme and large font                                           |
-
-
-#### Cider jack-in and reveal
-
-See the [Reveal section of Practicalli Clojure](https://practical.li/clojure/clojure-cli/data-browsers/reveal.html#using-reveal-with-nrepl-editors) for full details, including how to set up a `.dir-locals.el` configuration.
-
-`:inspect/reveal-cider` alias contains Reveal REPL with nrepl server and Emacs CIDER specific middleware
-
-`C-u cider-jack-in-clj` in CIDER to start a reveal REPL  (`SPC u , '` in Spacemacs)
-
-Edit the jack-in command by deleting the all the configuration after the `clojure` command and add the alias
-
-```shell
-clojure -M:inspect/reveal-cider
-```
-
-`:inspect/reveal-cider` is a light version of the above.
-
-#### Running different types of repl
-
-Using Clojure exec `-X` flag, the default repl function can be over-ridden on the command line, supplying the `io-prepl` or `remote-prepl` functions.
-
-* `clojure -X:inspect/reveal io-prepl :title '"I am a prepl repl"`
-* `clojure -X:inspect/reveal remote-prepl :title '"I am a remote prepl repl"'`
-
-#### Configure theme & font
-
-Add a custom theme and font via the `-J` command line option or create an alias using `:inspect/reveal-light` as an example.
-
-```shell
-clojure -M:inspect/reveal -J-Dvlaaad.reveal.prefs='{:theme :light :font-family "Ubuntu Mono" :font-size 32}'
-```
-
-#### Rebel Readline & Reveal: Add Reveal as tap> source
-
-Evaluate `(add-tap ((requiring-resolve 'vlaaad.reveal/ui)))` when using Rebel Readline to add Reveal as a tap source, showing `(tap> ,,,)` expressions in the reveal window, eg. `(tap> (map inc [1 2 3 4 5]))`.
-
-[Practicalli Clojure - data browsers section](http://practicalli.github.io/clojure/clojure-cli/data-browsers/reveal.html) has more details on using reveal.
-
-### Cognitect REBL (DEPRECATED)
-
-Visualise the results of each evaluation in the REPL in the REBL UI.  Navigate through complex data structures.
-
-> Cognitect REBL aliases requires [several separate install steps](http://practicalli.github.io/clojure/alternative-tools/clojure-cli/cognitect-rebl.html) before they are operational
-> Tested on Oracle JDK 8 and OpenJDK 11 (current long term support).  Other Java 11 JDK distributions may work, but not tested. Newer (short term release) may work, but will need the `org.openjdk` library version in the `:inspect/rebl` alias changed to match the version of Java used.
-
-* `inspect/rebl` - REBL, a visual data explorer (Java 11)
-* `inspect/rebl-java8` - REBL, a visual data explorer (Oracle Java 8)
-
-| Command                                                    | Description                                                      |
-|------------------------------------------------------------|------------------------------------------------------------------|
-| `clojure -M:inspect/rebl`                                  | Start REBL REPL and UI (Java 11 only)                            |
-| `clojure -M:inspect/rebl-java8`                            | REBL REPL and UI  (Oracle Java 8 only)                           |
-| `clojure -M:lib/cider-nrepl:inspect/rebl:middleware/nrebl` | REBL REPL and UI with nREPL server (CIDER, Calva) (Java 11 only) |
-
-## Middleware
-
-Aliases for libraries that combine community tools and REPL protocols (nREPL, SocketREPL).
-
-Run a REPL on the command line for access by `cider-connect-` commands, providing the require cider middleware libraries that are auto-injected in `cider-jack-in-` commands.
-
-### nREPL
-
-* `:middleware/nrepl` - Clojure REPL with an nREPL server
-* `:middleware/cider-clj` - Clojure REPL with nREPL server and CIDER dependencies for `cider-connect-clj`
-* `:middleware/cider-clj-refactor` - as :middleware/cider-clj with clj-refactor added
-* `:middleware/cider-cljs` - ClojureScript REPL with nREPL server and CIDER dependencies for `cider-connect-cljs`
-
-| Command                                    | Description                                                                                      |
-|--------------------------------------------|--------------------------------------------------------------------------------------------------|
-| `clojure -M:middleware/nrepl`              | Run a Clojure REPL that includes nREPL server                                                    |
-| `clojure -M:middleware/cider-clj`          | Run a Clojure REPL that includes nREPL server and CIDER connection dependencies                  |
-| `clojure -M:middleware/cider-clj-refactor` | Run a Clojure REPL that includes nREPL server and CIDER connection dependencies and clj-refactor |
-| `clojure -M:middleware/cider-cljs`         | Run a ClojureScript REPL that includes nREPL server and CIDER connection dependencies            |
-
-#### Figwheel-main project and cider-connect-cljs
-
-Open a terminal and run the REPL process with the command:
-
-```bash
-clojure -M:middleware/cider-cljs:fig
-```
-
-An nREPL server process is started along with the figwheel-main process.
-
-In Emacs, run the command `cider-connect-cljs`, select `figwheel-main` build tool and the `dev` build
-
-### Cognitect REBL with CIDER
-
-Run the REBL REPL with nREPL server so CIDER can connect.
-
-* `:middleware/nrebl` - REBL data browser on nREPL connection
-* `:lib/cider-nrepl` - include nrepl, cider-nrepl and refactor-nrepl library
-  dependencies (support `:inspect/nrebl` alias)
-
-In a terminal, run REBL listening to nREPL using the command
-
-```shell
-clojure -M:lib/cider-nrepl:inspect/rebl:middleware/nrebl
-```
-
-`cider-connect-clj` in Spacemacs / Emacs and CIDER successfully connects to the nREPL port and evaluated code is sent to REBL.
-
-To start a REBL REPL from `cider-jack-in-clj` add a `.dir-locals.el` file to the root of a Clojure project. The `.dir-locals.el` configuration adds the nREBL aliases set via `cider-clojure-cli-global-options` and all other automatically injected configuration is disabled (to prevent those dependencies over-riding the nREBL aliases).
-
-```elisp
-((clojure-mode . ((cider-preferred-build-tool . clojure-cli)
-                  (cider-clojure-cli-global-options . "-M:lib/cider-nrepl:inspect/rebl:middleware/nrebl")
-                  (cider-jack-in-dependencies . nil)
-                  (cider-jack-in-lein-plugins . nil)
-                  (cider-clojure-cli-parameters . ""))))
-```
-
-* [REBL data visualization: run REBL with nREPL based editors](https://practical.li/clojure/alternative-tools/clojure-cli/cognitect-rebl.html#configure-rebl-with-clojure-editors)
 
 ## Debug Tools
 
@@ -639,7 +442,9 @@ Include expectations as a development dependency in a project `clojure -M:env/te
 
 ## Test runners and Test Coverage tools
 
-Run unit tests in a project which are defined under the `test` path. See [Practicalli Clojure: Unit testing](https://practical.li/clojure/testing/unit-testing/)
+[Practicalli Clojure: Unit testing](https://practical.li/clojure/testing/) covers many aspects of testing for projects.  Kaocha is the main test runner used by Practicalli as it is simple to use and easily configurable to create an effective test workflow.
+
+Run unit tests in a project which are defined under the `test` path. See
 
 | Command                            | Description                                                                               |
 |------------------------------------|-------------------------------------------------------------------------------------------|
@@ -647,24 +452,12 @@ Run unit tests in a project which are defined under the `test` path. See [Practi
 | `clojure -X:test/watch`            | run tests in watch mode using Kaocha test runner for Clojure (same as :test/kaocha-watch) |
 | `clojure -X:test/cognitect`        | Cognitect Clojure test runner                                                             |
 | `clojure -X:test/coverage`         | Cloverage clojure.test coverage report                                                    |
-| `clojure -M:test/cljs`             | ClojureScript test runner (Olical)                                                        |
-| `clojure -X:test/kaocha`           | Kaocha - test runner for Clojure  (same as :test/run)                                     |
-| `clojure -M:test/kaocha-cljs`      | Kaocha - test runner for ClojureScript                                                    |
-| `clojure -M:test/kaocha-cucumber`  | Kaocha - test runner with BDD Cucumber tests                                              |
-| `clojure -M:test/kaocha-junit-xml` | Kaocha - test runner with Junit XML reporting for CI dashboards & wallboards              |
-| `clojure -M:test/kaocha-cloverage` | Kaocha - test runner with test coverage reporting                                         |
+| `clojure -M:test/cljs`             | ClojureScript test runner (Kaocha)                                                        |
 
 `:lib/kaocha` alias adds kaocha as a library to the class path, enabling scripts such as kaocha-runner.el to run Kaocha test runner from Emacs Cider
 
 > A `test.edn` [configuration file](https://cljdoc.org/d/lambdaisland/kaocha/1.0.829/doc/3-configuration) can be used with the :test/run alias instead of using various aliases defined above
-> Kaocha aliases can be run with `-T` execution option if both the `src` and `test` paths are included, either in the combined deps.edn config or in the `tests.edn` config.
 
-[kaocha recommends adding a `bin/kaocha` shell script](https://github.com/lambdaisland/kaocha#clojure-cli-toolsdeps) to run the tool, which can be written using the Practicalli aliases, for example:
-
-```bash
-#!/usr/bin/env sh
-clojure -X:test/run "$@"
-```
 
 ## Lint tools
 

--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ Run unit tests in a project which are defined under the `test` path. See
 
 `:lib/kaocha` alias adds kaocha as a library to the class path, enabling scripts such as kaocha-runner.el to run Kaocha test runner from Emacs Cider
 
-> A `test.edn` [configuration file](https://cljdoc.org/d/lambdaisland/kaocha/1.0.829/doc/3-configuration) can be used with the :test/run alias instead of using various aliases defined above
+> A `test.edn` [configuration file](https://cljdoc.org/d/lambdaisland/kaocha/1.77.1236/doc/3-configuration) can be used with the :test/run alias instead of using various aliases defined above
 
 
 ## Lint tools

--- a/deps-deprecated.edn
+++ b/deps-deprecated.edn
@@ -1,0 +1,410 @@
+;; ---------------------------------------------------------
+;; Clojure CLI Aliased deprecated
+;;
+;; Aliases once included in Practicalli Clojure CLI and
+;; no longer used.
+;; Aliases moved here as examples of how to write those aliases
+;; although they will not be actively maintained
+;; ---------------------------------------------------------
+
+{:aliases
+
+ {;; ---------------------------------------------------
+  ;;  REPL's
+  ;; Run an interactive Clojure REPL with nREPL connection and CIDER libraries
+  ;; clojure -M:repl/cider
+  :repl/cider
+  {:extra-deps {nrepl/nrepl       {:mvn/version "1.0.0"}
+                cider/cider-nrepl {:mvn/version "0.28.7"}}
+   :main-opts  ["-m" "nrepl.cmdline"
+                "--middleware" "[cider.nrepl/cider-middleware]"
+                "--interactive"]}
+
+  ;; End of REPL's
+  ;; ---------------------------------------------------
+
+  ;; ---------------------------------------------------
+  ;; Alternative REPL's
+
+  ;; Requires nashorn in a version of ClojureScript
+  ;; WARNING: stack trace - does not run TO DEPRECATE
+  :repl/rebel-figwheel
+  {:extra-deps {org.clojure/clojurescript       {:mvn/version "1.9.946"} ; version contains cljs.repl.nashorn
+                nrepl/nrepl                     {:mvn/version "1.0.0"}
+                com.bhauman/rebel-readline-cljs {:mvn/version "0.1.4"}
+                com.bhauman/figwheel-main       {:mvn/version "0.2.18"}
+                cider/cider-nrepl               {:mvn/version "0.28.7"}
+                cider/piggieback                {:mvn/version "0.5.3"}}
+   :main-opts  ["-m" "nrepl.cmdline"
+                "--interactive"
+                "--middleware" "[cider.nrepl/cider-middleware,cider.piggieback/wrap-cljs-repl]"
+                "-f" "rebel-readline.cljs.main/-main"]}
+
+  ;; Start a Clojure Socket pREPL on port 40404:
+  ;; clojure -M:repl/prepl
+  :repl/prepl
+  {:jvm-opts ["-Dclojure.server.repl={:port,40404,:accept,clojure.core.server/io-prepl}"]}
+
+  ;; Start a ClojureScript Socket pREPL on port 44444:
+  :repl/prepl-cljs
+  ;; clojure -M:repl/prepl-cljs
+  {:jvm-opts ["-Dclojure.server.repl={:port,44444,:accept,cljs.server.browser/prepl}"]}
+
+  ;; End of Alternative REPL's
+  ;; ---------------------------------------------------
+
+  ;; ---------------------------------------------------
+  ;; Projects and dependencies
+
+  :search/outdated
+  {:replace-paths ["."]
+   :replace-deps  {com.github.liquidz/antq {:mvn/version "2.2.962"}
+                   org.slf4j/slf4j-nop     {:mvn/version "2.0.5"}}
+   :exec-fn antq.tool/outdated
+   :exec-args {:directory ["."] ; default
+               :exclude ["com.cognitect/rebl"
+                         "org.openjfx/javafx-base"
+                         "org.openjfx/javafx-controls"
+                         "org.openjfx/javafx-fxml"
+                         "org.openjfx/javafx-swing"
+                         "org.openjfx/javafx-web"]
+               ;; :focus ["com.github.liquidz/antq"]
+               :skip ["boot" "leiningen"]
+               :reporter "table" ; json edn format
+               :verbose false
+               :upgrade false
+               :force   false}}
+
+  :hack/antq
+  {:replace-deps
+   {antq/antq {:local/root "/home/practicalli/projects/clojure/community-tools/antq"}}
+   :main-opts ["-m" "antq.core"]}
+
+  ;; The classic project for checking maven based dependencies
+  ;; clojure -M:search/outdated-mvn
+  ;; DEPRECATE
+  :search/outdated-mvn
+  {:replace-paths []
+   :replace-deps  {deps-ancient/deps-ancient {:mvn/version "0.0.5"}}
+   :main-opts     ["-m" "deps-ancient.deps-ancient"]}
+
+  ;; End of Projects and dependencies
+  ;; ---------------------------------------------------
+
+  ;; ---------------------------------------------------
+  ;; Format
+
+  :format/cljfmt-check
+  {:extra-deps {cljfmt/cljfmt {:mvn/version "0.9.0"}}
+   :main-opts ["-m" "cljfmt.main" "check"]}
+
+  ;; cljfmt-check - check/report formatting issues
+  :format/cljfmt-fix
+  {:extra-deps {cljfmt/cljfmt {:mvn/version "0.9.0"}}
+   :main-opts ["-m" "cljfmt.main" "fix"]}
+
+  ;; End of Format
+  ;; ---------------------------------------------------
+
+  ;; ---------------------------------------------------
+  ;; Project Packaging
+
+  ;; depstar - build jars, uberjars
+  ;; https://github.com/seancorfield/depstar
+  ;; over-ride the :main-class as the name is unlikely to match your project
+
+  ;; Jar archive of the project
+  ;; clojure -X:project/jar :main-class domain.application
+  ;; clojure -X:project/jar :jar '"project-name.jar"' :main-class domain.application
+  :project/jar
+  {:replace-deps {com.github.seancorfield/depstar {:mvn/version "2.1.303"}}
+   :exec-fn      hf.depstar/jar
+   :exec-args    {:jar "project.jar"
+                  :aot true}}
+
+  ;; Uberjar archive of the project, including Clojure runtime
+  ;; clojure -X:project/uberjar :main-class domain.application
+  ;; clojure -X:project/uberjar :jar '"project-name.jar"' :main-class domain.application
+  :project/uberjar
+  {:replace-deps {com.github.seancorfield/depstar {:mvn/version "2.1.303"}}
+   :exec-fn      hf.depstar/uberjar
+   :exec-args    {:jar "uber.jar"
+                  :aot true}}
+
+  ;; End of project packaging
+  ;; ---------------------------------------------------
+
+;; ---------------------------------------------------
+  ;; Data inspectors / visualizers
+
+  ;; REBL Data browser - TO DEPRECATE
+  ;; https://github.com/practicalli/clojure-deps-edn#cognitect-rebl
+  ;; http://practicalli.github.io/clojure/alternative-tools/clojure-tools/cognitect-rebl.html
+  ;; Requires Clojure 1.10 or greater
+  ;; Requires Cognitect dev-tools https://cognitect.com/dev-tools/index.html
+  ;; :inspect/rebl-java8   (Oracle JDK 8 only)
+  ;; :inspect/rebl         (Any JDK 11 distribution - tested with OpenJDK)
+
+  ;; :inspect/:rebl        ;; for JDK 11+
+  ;;  {:extra-deps {com.cognitect/rebl          {:mvn/version "0.9.245"}
+  ;;                org.openjfx/javafx-fxml     {:mvn/version "15-ea+6"}
+  ;;                org.openjfx/javafx-controls {:mvn/version "15-ea+6"}
+  ;;                org.openjfx/javafx-swing    {:mvn/version "15-ea+6"}
+  ;;                org.openjfx/javafx-base     {:mvn/version "15-ea+6"}
+  ;;                org.openjfx/javafx-web      {:mvn/version "15-ea+6"}}
+  ;;   :main-opts  ["-m" "cognitect.rebl"]}
+
+  ;; :rebl-jdk8   ;; for JDK 8
+  ;;  {:extra-deps {com.cognitect/rebl {:mvn/version "0.9.245"}}
+  ;;   :main-opts  ["-m" "cognitect.rebl"]}}
+
+  ;; Reveal - read evaluate visualize loop
+  ;; A REPL environment with data visualization and exploration
+  ;; http://practicalli.github.io/clojure/clojure-tools/data-browsers/reveal.html
+  ;; clojure -X:inspect/reveal
+  ;; Run with theme / font changes:
+  ;; clojure -X:inspect/reveal-light
+  ;; Use with rebel repl by adding and using tap>
+  ;; clojure -M:inspect/reveal-rebel
+  ;; clojure -M:inspect/reveal:rebel -J-Dvlaaad.reveal.prefs='{:theme :light :font-family "Ubuntu Mono" :font-size 32}'
+
+  ;; rebel readline with reveal data visualization
+  ;; NOTE: :repl/revel-reveal alias is very much a hack and not a good example to follow
+  ;; clojure -M:repl/rebel-reveal
+  :repl/rebel-reveal
+  {:extra-deps
+   {vlaaad/reveal              {:mvn/version "1.3.276"}
+    com.bhauman/rebel-readline {:mvn/version "0.1.4"}}
+   :jvm-opts  ["-Dvlaaad.reveal.prefs={:theme,:light,:font-family,\"https://ff.static.1001fonts.net/u/b/ubuntu.mono.ttf\",:font-size,32}"]
+   :main-opts ["-e" "(require,'rebel-readline.core),(require,'rebel-readline.clojure.line-reader),(require,'rebel-readline.clojure.service.local),(require,'rebel-readline.clojure.main),(require,'vlaaad.reveal)(rebel-readline.core/with-line-reader,(rebel-readline.clojure.line-reader/create,(rebel-readline.clojure.service.local/create)),(vlaaad.reveal/repl,:prompt,(fn,[]),:read,(rebel-readline.clojure.main/create-repl-read)))"]}
+
+  ;; clojure -M:repl/reveal-light-rebel
+  :repl/rebel-reveal-light
+  {:extra-deps
+   {vlaaad/reveal              {:mvn/version "1.3.276"}
+    com.bhauman/rebel-readline {:mvn/version "0.1.4"}}
+   :jvm-opts  ["-Dvlaaad.reveal.prefs={:theme,:light,:font-family,\"https://ff.static.1001fonts.net/u/b/ubuntu.mono.ttf\",:font-size,32}"]
+   :main-opts ["-e" "(require,'rebel-readline.core),(require,'rebel-readline.clojure.line-reader),(require,'rebel-readline.clojure.service.local),(require,'rebel-readline.clojure.main),(require,'vlaaad.reveal)(rebel-readline.core/with-line-reader,(rebel-readline.clojure.line-reader/create,(rebel-readline.clojure.service.local/create)),(vlaaad.reveal/repl,:prompt,(fn,[]),:read,(rebel-readline.clojure.main/create-repl-read)))"]}
+
+  :inspect/reveal
+  {:extra-deps {vlaaad/reveal {:mvn/version "1.3.276"}}
+   :exec-fn    vlaaad.reveal/repl
+   :main-opts  ["-m" "vlaaad.reveal" "repl"]}
+
+  :inspect/reveal-light
+  {:extra-deps {vlaaad/reveal {:mvn/version "1.3.276"}}
+   :exec-fn    vlaaad.reveal/repl
+   :jvm-opts   ["-Dvlaaad.reveal.prefs={:theme,:light,:font-family,\"https://ff.static.1001fonts.net/u/b/ubuntu.mono.ttf\",:font-size,32}"]
+   :main-opts  ["-m" "vlaaad.reveal" "repl"]}
+
+  ;; Not sending all evaluations to Reveal
+  ;; It does send tap> results to Reveal
+  ;; :repl/reveal-rebel-nrepl
+  ;; {:extra-deps {nrepl/nrepl                {:mvn/version "0.9.0"}
+  ;;               cider/cider-nrepl          {:mvn/version "0.28.7"}
+  ;;               vlaaad/reveal              {:mvn/version "1.3.276"}
+  ;;               com.bhauman/rebel-readline {:mvn/version "0.1.4"}}
+  ;;  :jvm-opts   ["-Dvlaaad.reveal.prefs={:theme,:light,:font-family,\"https://ff.static.1001fonts.net/u/b/ubuntu.mono.ttf\",:font-size,32}"]
+  ;;  :main-opts  ["-m" "nrepl.cmdline"
+  ;;               "--middleware" "[cider.nrepl/cider-middleware,vlaaad.reveal.nrepl/middleware]"
+  ;;               "-f" "rebel-readline.main/-main"]}
+
+  :inspect/reveal-local ; Hacking the project
+  {:extra-deps {vlaaad/reveal
+                {:local/root "/home/practicalli/projects/clojure/visualization/reveal/"}}
+   :main-opts  ["-m" "vlaaad.reveal" "repl"]}
+
+  ;; Reveal with Clojure editors
+  ;; clj -M:inspect/reveal-nrepl
+  ;; add the -i flag for interactive REPL client
+  ;; Reveal REPL with nrepl server, connect to from a Clojure aware editor
+  :inspect/reveal-nrepl
+  {:extra-deps {vlaaad/reveal {:mvn/version "1.3.276"}
+                nrepl/nrepl   {:mvn/version "1.0.0"}}
+   :main-opts  ["-m" "nrepl.cmdline"
+                "--middleware" "[vlaaad.reveal.nrepl/middleware]"]}
+
+  ;; Light version of :inspect/reveal-nrepl
+  :inspect/reveal-light-nrepl
+  {:extra-deps {vlaaad/reveal {:mvn/version "1.3.276"}
+                nrepl/nrepl   {:mvn/version "1.0.0"}}
+   :jvm-opts   ["-Dvlaaad.reveal.prefs={:theme,:light,:font-family,\"https://ff.static.1001fonts.net/u/b/ubuntu.mono.ttf\",:font-size,32}"]
+   :main-opts  ["-m" "nrepl.cmdline"
+                "--middleware" "[vlaaad.reveal.nrepl/middleware]"]}
+
+  ;; Reveal with headless nrepl server and Emacs CIDER specific middleware
+  ;; Use with `C-u cider-jack-in-clj` or `SPC u , '` on Spacemacs
+  ;; Edit jack-in command: clojure -M:inspect/reveal-nrepl-cider
+  :inspect/reveal-cider
+  {:extra-deps {vlaaad/reveal                 {:mvn/version "1.3.276"}
+                nrepl/nrepl                   {:mvn/version "1.0.0"}
+                cider/cider-nrepl             {:mvn/version "0.28.7"}
+                refactor-nrepl/refactor-nrepl {:mvn/version "3.6.0"}}
+   :main-opts  ["-m" "nrepl.cmdline"
+                "--middleware" "[vlaaad.reveal.nrepl/middleware,refactor-nrepl.middleware/wrap-refactor,cider.nrepl/cider-middleware]"]}
+
+  ;; Light version of :inspect/reveal-nrepl-cider
+  :inspect/reveal-light-cider
+  {:extra-deps {vlaaad/reveal                 {:mvn/version "1.3.276"}
+                nrepl/nrepl                   {:mvn/version "1.0.0"}
+                cider/cider-nrepl             {:mvn/version "0.28.7"}
+                refactor-nrepl/refactor-nrepl {:mvn/version "3.6.0"}}
+   :jvm-opts   ["-Dvlaaad.reveal.prefs={:theme,:light,:font-family,\"https://ff.static.1001fonts.net/u/b/ubuntu.mono.ttf\",:font-size,32}"]
+   :main-opts  ["-m" "nrepl.cmdline"
+                "--middleware" "[vlaaad.reveal.nrepl/middleware,refactor-nrepl.middleware/wrap-refactor,cider.nrepl/cider-middleware]"]}
+
+  ;; End of Data Inspectors
+  ;; ---------------------------------------------------
+
+  ;; ---------------------------------------------------
+  ;; Middleware
+
+  ;; Run a REPL using nREPL server for access by cider-connect-clj
+  ;; clojure -M:middleware/cider-clj
+  :middleware/cider-clj
+  {:extra-deps {nrepl/nrepl       {:mvn/version "1.0.0"}
+                cider/cider-nrepl {:mvn/version "0.28.7"}}
+   :main-opts  ["-m" "nrepl.cmdline"
+                "--middleware" "[cider.nrepl/cider-middleware]"]}
+
+  :middleware/cider-clj-refactor
+  {:extra-deps {nrepl/nrepl                   {:mvn/version "1.0.0"}
+                refactor-nrepl/refactor-nrepl {:mvn/version "3.6.0"}
+                cider/cider-nrepl             {:mvn/version "0.28.7"}}
+   :main-opts  ["-m" "nrepl.cmdline"
+                "--middleware" "[refactor-nrepl.middleware/wrap-refactor,cider.nrepl/cider-middleware]"]}
+
+  ;; Run a REPL using nREPL server for access by cider-connect-cljs
+  ;; clojure -M:middleware/cider-cljs
+  ;; Using figwheel-main template and cider-connect-cljs: clojure -M:middleware/cider-cljs:fig
+  :middleware/cider-cljs
+  {:extra-deps {org.clojure/clojurescript {:mvn/version "1.10.844"}
+                nrepl/nrepl               {:mvn/version "1.0.0"}
+                cider/cider-nrepl         {:mvn/version "0.28.7"}
+                cider/piggieback          {:mvn/version "0.5.3"}}
+   :main-opts  ["-m" "nrepl.cmdline"
+                "--middleware" "[cider.nrepl/cider-middleware,cider.piggieback/wrap-cljs-repl]"]}
+
+  ;; nrebl.middleware - REBL with nREPL server
+  ;; visualize evaluations over nREPL in REBL data browser (CIDER, Calva)
+  ;; https://github.com/RickMoynihan/nrebl.middleware
+  ;; Emacs cider `dir-locals.el` configuration
+  ;; ((clojure-mode . ((cider-clojure-cli-global-options . "-M:lib/cider-nrepl:inspect/rebl:middleware/nrebl"))))
+
+  ;; clojure -M:lib/cider-nrepl:inspect/rebl:middleware/nrebl
+  :middleware/nrebl
+  {:extra-deps {rickmoynihan/nrebl.middleware {:mvn/version "0.3.1"}}
+   :main-opts  ["-e" "((requiring-resolve,'cognitect.rebl/ui))"
+                "-m" "nrepl.cmdline"
+                "--interactive"
+                "--middleware" "[nrebl.middleware/wrap-nrebl,cider.nrepl/cider-middleware]"]}
+
+  ;; Supporting aliases for nrebl.middleware
+  :lib/cider-nrepl
+  {:extra-deps {nrepl/nrepl                   {:mvn/version "1.0.0"}
+                cider/cider-nrepl             {:mvn/version "0.28.7"}
+                refactor-nrepl/refactor-nrepl {:mvn/version "3.6.0"}}}
+
+  ;; End of Middleware
+  ;; ---------------------------------------------------
+
+  ;; Testing frameworks
+  ;; ---------------------------------------------------
+
+  ;; Expectations test framework
+  ;; https://github.com/clojure-expectations/clojure-test
+  ;; Example usage:
+  ;; clojure -M:expectations:test/cognitect
+  :lib/expectations
+  {:extra-deps {expectations/clojure-test {:mvn/version "1.2.1"}}}
+
+  ;; Classic version not compatible with clojure.test and tools
+  ;; https://github.com/clojure-expectations/expectations
+  :lib/expectations-classic
+  {:extra-deps {expectations/expectations {:mvn/version "2.1.10"}}}
+
+  ;; End of Testing frameworks
+  ;; ---------------------------------------------------
+
+;; ---------------------------------------------------
+  ;; Test runners
+
+  ;; Experiment: test using alternative configuration
+  :test/kaocha-global
+  {:extra-paths ["test"]
+   :extra-deps {lambdaisland/kaocha {:mvn/version "1.71.1119"}}
+   :exec-fn kaocha.runner/exec-fn
+   :exec-args {:config-file ["~/.clojure/kaocha-global-tests.edn"]}}
+
+  ;; clojure -X:test/kaocha
+  :test/kaocha
+  {:extra-paths ["test"]
+   :extra-deps {lambdaisland/kaocha {:mvn/version "1.71.1119"}}
+   :main-opts   ["-m" "kaocha.runner"]
+   :exec-fn kaocha.runner/exec-fn
+   :exec-args {}}
+
+  ;; clojure -X:test/kaocha-watch
+  :test/kaocha-watch
+  {:extra-paths ["test"]
+   :extra-deps  {lambdaisland/kaocha {:mvn/version "1.71.1119"}}
+   :main-opts   ["-m" "kaocha.runner" "--watch" "--fail-fast" "--skip-meta" ":slow"]
+   :exec-fn kaocha.runner/exec-fn
+   :exec-args {:watch? true
+               :randomize? false
+               :fail-fast? true}}
+
+  ;; clojure -M:test/kaocha-cljs
+  :test/kaocha-cljs
+  {:extra-paths ["test"]
+   :extra-deps  {lambdaisland/kaocha      {:mvn/version "1.71.1119"}
+                 lambdaisland/kaocha-cljs {:mvn/version "1.4.130"}}
+   :main-opts   ["-m" "kaocha.runner" "unit-cljs"]}
+
+;; End of Test runners
+  ;; ---------------------------------------------------
+
+;; midje-runner
+  ;; https://github.com/miorimmax/midje-runner
+  :test/midje
+  {:extra-paths ["test"]
+   :extra-deps  {midge-runner/midje-runner
+                 {:git/url "https://github.com/miorimmax/midje-runner.git"
+                  :sha     "ee9c2813e150ae6b3ea41b446b09ba40fc89bdc1"}}
+   :main-opts   ["-m" "midje-runner.runner"]}
+
+  ;; uberdeps - https://github.com/tonsky/uberdeps
+  ;; recommend depstar until that is migrated into tools.build
+  :project/uberdeps
+  {:replace-paths []
+   :replace-deps  {uberdeps/uberdeps {:mvn/version "1.1.4"}}
+   :main-opts     ["-m" "uberdeps.uberjar"]}
+
+;; ---------------------------------------------------
+  ;; Hot loading dependencies - EXPERIMENTAL / APLPHA
+  ;; ---------------------------------------------------
+  ;; Hot loading is not officially part of tools.deps and could change in future
+  ;; https://practical.li/clojure/alternative-tools/clojure-tools/hotload-libraries.html
+
+  ;; Add new deps to a running REPL:
+  ;; (require '[clojure.tools.deps.alpha.repl :refer [add-libs]])
+  ;; (add-libs 'domain/library {:mvn/version "1.0.1"})
+  ;; Git deps
+  ;; (require '[clojure.tools.gitlibs :as gitlibs])
+  ;; (defn load-master [lib]
+  ;;   (let [git (str "https://github.com/" lib ".git")]
+  ;;    (add-lib lib {:git/url git :sha (gitlibs/resolve git "master")})))
+  ;; - e.g., using the GitHub path (not the usual Maven group/artifact):
+  ;; (load-master 'clojure/tools.trace)
+
+  :alpha/hotload-socket
+  {:extra-deps {org.clojure/tools.deps.alpha
+                ;; Latest commit on add-lib3 branch, don't update with :search/outdated
+                {:git/url "https://github.com/clojure/tools.deps.alpha"
+                 :sha     "e4fb92eef724fa39e29b39cc2b1a850567d490dd"}
+                ;; Set logging implementation to no-operation
+                org.slf4j/slf4j-nop {:mvn/version "2.0.5"}}
+   ;; DynamicClassLoader required when starting other processes via aliases, e.g. socket REPL or Cognitect's REBL
+   :main-opts  ["-e" "(->>(Thread/currentThread)(.getContextClassLoader)(clojure.lang.DynamicClassLoader.)(.setContextClassLoader,(Thread/currentThread)))"]}
+
+  #_()}}

--- a/deps-deprecated.edn
+++ b/deps-deprecated.edn
@@ -101,7 +101,7 @@
   ;; End of Projects and dependencies
   ;; ---------------------------------------------------
 
-;; ---------------------------------------------------
+  ;; ---------------------------------------------------
   ;; Test Runners
 
   ;; ClojureScript test runner
@@ -171,7 +171,7 @@
   ;; End of project packaging
   ;; ---------------------------------------------------
 
-;; ---------------------------------------------------
+  ;; ---------------------------------------------------
   ;; Data inspectors / visualizers
 
   ;; REBL Data browser - TO DEPRECATE
@@ -363,7 +363,7 @@
   ;; End of Testing frameworks
   ;; ---------------------------------------------------
 
-;; ---------------------------------------------------
+  ;; ---------------------------------------------------
   ;; Test runners
 
   ;; Experiment: test using alternative configuration
@@ -398,10 +398,10 @@
                  lambdaisland/kaocha-cljs {:mvn/version "1.4.130"}}
    :main-opts   ["-m" "kaocha.runner" "unit-cljs"]}
 
-;; End of Test runners
+  ;; End of Test runners
   ;; ---------------------------------------------------
 
-;; midje-runner
+  ;; midje-runner
   ;; https://github.com/miorimmax/midje-runner
   :test/midje
   {:extra-paths ["test"]
@@ -417,7 +417,7 @@
    :replace-deps  {uberdeps/uberdeps {:mvn/version "1.1.4"}}
    :main-opts     ["-m" "uberdeps.uberjar"]}
 
-;; ---------------------------------------------------
+  ;; ---------------------------------------------------
   ;; Hot loading dependencies - EXPERIMENTAL / APLPHA
   ;; ---------------------------------------------------
   ;; Hot loading is not officially part of tools.deps and could change in future

--- a/deps-deprecated.edn
+++ b/deps-deprecated.edn
@@ -11,6 +11,16 @@
 
  {;; ---------------------------------------------------
   ;;  REPL's
+
+  ;; Simple nREPL server REPL, headless
+  ;; call with -i flag to start interactive client
+  :repl/nrepl
+  {:extra-deps {nrepl/nrepl {:mvn/version "1.0.0"}
+                cider/cider-nrepl {:mvn/version "0.28.7"}}
+   :main-opts  ["-m" "nrepl.cmdline"
+                "--middleware" "[cider.nrepl/cider-middleware]"
+                "--interactive"]}
+
   ;; Run an interactive Clojure REPL with nREPL connection and CIDER libraries
   ;; clojure -M:repl/cider
   :repl/cider
@@ -89,6 +99,33 @@
    :main-opts     ["-m" "deps-ancient.deps-ancient"]}
 
   ;; End of Projects and dependencies
+  ;; ---------------------------------------------------
+
+;; ---------------------------------------------------
+  ;; Test Runners
+
+  ;; ClojureScript test runner
+  ;; https://github.com/Olical/cljs-test-runner
+  :test/cljs
+  {:extra-paths ["test"]
+   :extra-deps  {olical/cljs-test-runner {:mvn/version "3.8.0"}}
+   :main-opts   ["-m" "cljs-test-runner.main"]}
+
+  ;; End of Test Runners
+  ;; ---------------------------------------------------
+
+  ;; ---------------------------------------------------
+  ;; Middleware
+
+  ;; - start a non-interactive REPL with a headless nREPL server
+  ;; clojure -M:middleware/nrepl
+  :middleware/nrepl
+  {:extra-deps {nrepl/nrepl {:mvn/version "1.0.0"}
+                cider/cider-nrepl {:mvn/version "0.28.7"}}
+   :main-opts  ["-m" "nrepl.cmdline"
+                "--middleware" "[cider.nrepl/cider-middleware]"]}
+
+  ;; End of: Middleware
   ;; ---------------------------------------------------
 
   ;; ---------------------------------------------------

--- a/deps.edn
+++ b/deps.edn
@@ -200,6 +200,22 @@
                 "--interactive"
                 "-f" "rebel-readline.main/-main"]}
 
+  :repl/reloaded
+  {:extra-deps {nrepl/nrepl                {:mvn/version "1.0.0"}
+                cider/cider-nrepl          {:mvn/version "0.28.7"}
+                com.bhauman/rebel-readline {:mvn/version "0.1.4"}
+                djblue/portal {:mvn/version "0.34.2"}
+                org.clojure/tools.namespace {:mvn/version "1.3.0"}
+                org.clojure/tools.deps.alpha {:git/url "https://github.com/clojure/tools.deps.alpha"
+                                              :git/sha "e4fb92eef724fa39e29b39cc2b1a850567d490dd"}
+                org.slf4j/slf4j-nop {:mvn/version "2.0.5"}
+                org.clojure/test.check {:mvn/version "1.1.1"}
+                ring/ring-mock         {:mvn/version "0.4.0"}}
+   :main-opts  ["-m" "nrepl.cmdline"
+                "--middleware" "[cider.nrepl/cider-middleware]"
+                "--interactive"
+                "-f" "rebel-readline.main/-main"]}
+
   ;; ClojureScript REPL with rebel readline with nrepl for editor connection
   ;; https://github.com/bhauman/rebel-readline/tree/master/rebel-readline-cljs
   ;; CIDER: run `cider-connect-cljs` and select REPL host and port, figwheel-main and dev build

--- a/deps.edn
+++ b/deps.edn
@@ -65,7 +65,7 @@
  ;; End of Library Repositories
  ;; ---------------------------------------------------
 
-;; ---------------------------------------------------
+ ;; ---------------------------------------------------
  ;; User alias definitions
 
  :aliases
@@ -272,7 +272,7 @@
    :exec-fn      org.corfield.new/create
    :exec-args    {:template app :name practicalli/playground}}
 
-;; Convert Leiningen projects to Clojure CLI with depify
+  ;; Convert Leiningen projects to Clojure CLI with depify
   ;; Use `lein pprint` when `project.clj` includes quoted variables or paths to resolve
   ;; `lein pprint | clojure -M:project/depify`
   :project/depify
@@ -329,7 +329,7 @@
                :upgrade false
                :force   false}}
 
-;; Carve - search through code for unused vars and remove them
+  ;; Carve - search through code for unused vars and remove them
   ;; clojure -M:search/unused-vars --opts '{:paths ["src" "test"]}'
   :search/unused-vars
   {:extra-deps {borkdude/carve
@@ -540,7 +540,7 @@
    :main-opts   ["-m" "cognitect.test-runner"]
    :exec-fn cognitect.test-runner.api/test}
 
-;; kaocha - comprehensive test runner for Clojure/Script
+  ;; kaocha - comprehensive test runner for Clojure/Script
   ;; tests.edn should be created for each project
   ;; https://github.com/lambdaisland/kaocha
 

--- a/deps.edn
+++ b/deps.edn
@@ -79,6 +79,16 @@
   :env/dev
   {:extra-paths ["dev"]}
 
+  :dev/reloaded
+  {:extra-paths ["dev" "test"]
+   :extra-deps  {djblue/portal {:mvn/version "0.34.2"}
+                 org.clojure/tools.namespace {:mvn/version "1.3.0"}
+                 org.clojure/tools.deps.alpha {:git/url "https://github.com/clojure/tools.deps.alpha"
+                                               :git/sha "e4fb92eef724fa39e29b39cc2b1a850567d490dd"}
+                 org.slf4j/slf4j-nop {:mvn/version "2.0.5"}
+                 org.clojure/test.check {:mvn/version "1.1.1"}
+                 ring/ring-mock         {:mvn/version "0.4.0"}}}
+
   :lib/nrepl
   {:extra-deps {nrepl/nrepl {:mvn/version "1.0.0"}}}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,33 +1,29 @@
-;; The deps.edn file describes the information needed to build a classpath.
-;; Source: https://github.com/practicalli/clojure-deps-edn
+;; --------------------------------------------------
+;; Practicalli Clojure CLI Configuration
 ;;
-;; deps.edn configuration is a combination of
-;; - install-level (latest Clojure version at install time)
-;; - user level - $HOME/.clojure/deps.edn
-;; - project level - deps.edn in root of project
-;;
-;; For all attributes other than :paths, these config files are merged left to right.
-;; Only the last :paths is kept and others are dropped.
-;; In an :alias, only the last :main-opts is kept and others are dropped.
+;; Aliases that extend the features of the Clojure CLI
+;; using Community projects as tools and libraries
+;; to enhanced the development workflow
+;; --------------------------------------------------
+
 
 ;; --------------------------------------------------
 ;; Top-level keys for Clojure CLI deps.edn
 
-;; :mvn/repositories
-;; :mvn/local-repo
-;; :paths
-;; :aliases
+;; :mvn/repositories - Maven & Clojars repositories, examples of other repositories
+;; :mvn/local-repo   - example of setting a local repository path
+;; :aliases          - tools to enhance a development workflow
+;; :paths            - not included in this configuration
+;; :deps             - not included in this configuration
 
-;; All other keys should be used within :aliases
-
-;; Aliases keys
-;;   resolve-deps aliases (-R) affect dependency resolution, options:
-;;     :extra-deps - specifies extra deps to add to :deps
-;;     :override-deps - specifies a coordinate to use instead of that in :deps
-;;     :default-deps - specifies a coordinate to use for a lib if one isn't found
-;;   make-classpath aliases (-C) affect the classpath generation, options:
-;;     :extra-paths - vector of additional paths to add to the classpath
-;;     :classpath-overrides - map of lib to path that overrides the result of resolving deps
+;; Keys used within :aliases
+;;  resolve-deps aliases (-R) affect dependency resolution, options:
+;;    :extra-deps - specifies extra deps to add to :deps
+;;    :override-deps - specifies a coordinate to use instead of that in :deps
+;;    :default-deps - specifies a coordinate to use for a lib if one isn't found
+;;  make-classpath aliases (-C) affect the classpath generation, options:
+;;    :extra-paths - vector of additional paths to add to the classpath
+;;    :classpath-overrides - map of lib to path that overrides the result of resolving deps
 ;; ---------------------------------------------------
 
 
@@ -70,27 +66,7 @@
  ;; ---------------------------------------------------
 
 ;; ---------------------------------------------------
- ;; Default Paths
- ;; Directories to include in the classpath to run the application
- ;; Development only paths should be defined in aliases, eg. :env/dev
- ;; Project deps.edn file superceeds this setting
- :paths ["src"]
-
- ;; End of: Default Paths
- ;; ---------------------------------------------------
-
-;; ---------------------------------------------------
- ;; Main dependencies
-
- ;; :deps
- ;; ;; Clojure standard library
- ;; {org.clojure/clojure {:mvn/version "1.11.1"}}
-
- ;; End of: Main dependencies
- ;; ---------------------------------------------------
-
-;; ---------------------------------------------------
- ;; User-level alias definitions
+ ;; User alias definitions
 
  :aliases
  {;; ---------------------------------------------------
@@ -146,8 +122,11 @@
   ;; Simple nREPL server REPL, headless
   ;; call with -i flag to start interactive client
   :repl/nrepl
-  {:extra-deps {nrepl/nrepl {:mvn/version "1.0.0"}}
-   :main-opts  ["-m" "nrepl.cmdline"]}
+  {:extra-deps {nrepl/nrepl {:mvn/version "1.0.0"}
+                cider/cider-nrepl {:mvn/version "0.28.7"}}
+   :main-opts  ["-m" "nrepl.cmdline"
+                "--middleware" "[cider.nrepl/cider-middleware]"
+                "--interactive"]}
 
   ;; Interactive client REPL with nREPL server for Clojure Editor support
   :repl/interactive
@@ -164,16 +143,7 @@
    :main-opts  ["-m" "nrepl.cmdline"
                 "--middleware" "[cider.nrepl/cider-middleware]"]}
 
-  ;; Run an interactive Clojure REPL with nREPL connection and CIDER libraries
-  ;; clojure -M:repl/cider
-  :repl/cider
-  {:extra-deps {nrepl/nrepl       {:mvn/version "1.0.0"}
-                cider/cider-nrepl {:mvn/version "0.28.7"}}
-   :main-opts  ["-m" "nrepl.cmdline"
-                "--middleware" "[cider.nrepl/cider-middleware]"
-                "--interactive"]}
-
-  :repl/cider-refactor
+  :repl/refactor
   {:extra-deps {nrepl/nrepl                   {:mvn/version "1.0.0"}
                 cider/cider-nrepl             {:mvn/version "0.28.7"}
                 refactor-nrepl/refactor-nrepl {:mvn/version "3.6.0"}}
@@ -182,7 +152,7 @@
                 "--interactive"]}
 
   ;; clojure -M:repl/cider-cljs
-  :repl/cider-cljs
+  :repl/cljs
   {:extra-deps {org.clojure/clojurescript       {:mvn/version "1.10.773"}
                 nrepl/nrepl                     {:mvn/version "1.0.0"}
                 cider/cider-nrepl               {:mvn/version "0.28.7"}
@@ -227,38 +197,6 @@
   {:extra-deps {com.bhauman/rebel-readline-cljs {:mvn/version "0.1.4"}}
    :main-opts  ["-m" "rebel-readline-cljs.main"]}
 
-  ;; Requires nashorn in a version of ClojureScript
-  ;; WARNING: stack trace - does not run TO DEPRECATE
-  :repl/rebel-figwheel
-  {:extra-deps {org.clojure/clojurescript       {:mvn/version "1.9.946"} ; version contains cljs.repl.nashorn
-                nrepl/nrepl                     {:mvn/version "1.0.0"}
-                com.bhauman/rebel-readline-cljs {:mvn/version "0.1.4"}
-                com.bhauman/figwheel-main       {:mvn/version "0.2.18"}
-                cider/cider-nrepl               {:mvn/version "0.28.7"}
-                cider/piggieback                {:mvn/version "0.5.3"}}
-   :main-opts  ["-m" "nrepl.cmdline"
-                "--interactive"
-                "--middleware" "[cider.nrepl/cider-middleware,cider.piggieback/wrap-cljs-repl]"
-                "-f" "rebel-readline.cljs.main/-main"]}
-
-  ;; rebel readline with reveal data visualization
-  ;; NOTE: :repl/revel-reveal alias is very much a hack and not a good example to follow
-  ;; clojure -M:repl/rebel-reveal
-  :repl/rebel-reveal
-  {:extra-deps
-   {vlaaad/reveal              {:mvn/version "1.3.276"}
-    com.bhauman/rebel-readline {:mvn/version "0.1.4"}}
-   :jvm-opts  ["-Dvlaaad.reveal.prefs={:theme,:light,:font-family,\"https://ff.static.1001fonts.net/u/b/ubuntu.mono.ttf\",:font-size,32}"]
-   :main-opts ["-e" "(require,'rebel-readline.core),(require,'rebel-readline.clojure.line-reader),(require,'rebel-readline.clojure.service.local),(require,'rebel-readline.clojure.main),(require,'vlaaad.reveal)(rebel-readline.core/with-line-reader,(rebel-readline.clojure.line-reader/create,(rebel-readline.clojure.service.local/create)),(vlaaad.reveal/repl,:prompt,(fn,[]),:read,(rebel-readline.clojure.main/create-repl-read)))"]}
-
-  ;; clojure -M:repl/reveal-light-rebel
-  :repl/rebel-reveal-light
-  {:extra-deps
-   {vlaaad/reveal              {:mvn/version "1.3.276"}
-    com.bhauman/rebel-readline {:mvn/version "0.1.4"}}
-   :jvm-opts  ["-Dvlaaad.reveal.prefs={:theme,:light,:font-family,\"https://ff.static.1001fonts.net/u/b/ubuntu.mono.ttf\",:font-size,32}"]
-   :main-opts ["-e" "(require,'rebel-readline.core),(require,'rebel-readline.clojure.line-reader),(require,'rebel-readline.clojure.service.local),(require,'rebel-readline.clojure.main),(require,'vlaaad.reveal)(rebel-readline.core/with-line-reader,(rebel-readline.clojure.line-reader/create,(rebel-readline.clojure.service.local/create)),(vlaaad.reveal/repl,:prompt,(fn,[]),:read,(rebel-readline.clojure.main/create-repl-read)))"]}
-
   :lib/rebel
   {:extra-deps {com.bhauman/rebel-readline {:mvn/version "0.1.4"}}}
 
@@ -290,62 +228,6 @@
   ;; ---------------------------------------------------
 
   ;; ---------------------------------------------------
-  ;; Alternative REPLs - not extensively tested
-
-  ;; Clojure Socket REPL on port 55555:
-  ;; clojure -X:repl/socket
-  :repl/socket
-  {:exec-fn clojure.core.server/start-server
-   :exec-args {:name "repl-server"
-               :port 55555
-               :accept clojure.core.server/repl
-               :server-daemon false}}
-
-  ;; Older Socket REPL approaches to review:
-
-  ;; clojure -M:repl/socket-jvm-opts (lesser used approach)
-  :repl/socket-jvm-opts
-  {:jvm-opts ["-Dclojure.server.repl={:port,50505,:accept,clojure.core.server/repl}"]}
-
-  ;; Clojure Socket REPL on an available port, displaying port number (container/cloud environments)
-  ;; - specify -r to start a repl
-  :repl/socket-zero
-  {:jvm-opts  ["-Dclojure.server.repl={:port,0,:accept,clojure.core.server/repl}"]
-   :main-opts ["-e" "(.getLocalPort,(get-in,@#'clojure.core.server/servers,[\"repl\",:socket]))"]}
-
-  ;; ClojureScript (node) Socket REPL on port 55555:
-  ;; clojure -M:repl/socket-cljs
-  :repl/socket-node
-  {:jvm-opts ["-Dclojure.server.repl={:port,55555,:accept,cljs.server.node/repl}"]}
-
-  ;; ClojureScript (browser) Socket REPL on port 58585:
-  ;; clojure -M:repl/socket-cljs
-  :repl/socket-browser
-  {:jvm-opts ["-Dclojure.server.repl={:port,58585,:accept,cljs.server.browser/repl}"]}
-
-  ;; tubular - socket repl client
-  ;; https://github.com/mfikes/tubular
-  ;; Connect to a socket repl, e.g. :repl/socket
-  ;; clojure -M:repl/socket-client
-  :repl/socket-client
-  {:extra-deps {tubular/tubular {:mvn/version "1.4.0"}}
-   :main-opts  ["-m" "tubular.core"
-                "-p" "55555"]}
-
-  ;; Start a Clojure Socket pREPL on port 40404:
-  ;; clojure -M:repl/prepl
-  :repl/prepl
-  {:jvm-opts ["-Dclojure.server.repl={:port,40404,:accept,clojure.core.server/io-prepl}"]}
-
-  ;; Start a ClojureScript Socket pREPL on port 44444:
-  :repl/prepl-cljs
-  ;; clojure -M:repl/prepl-cljs
-  {:jvm-opts ["-Dclojure.server.repl={:port,44444,:accept,cljs.server.browser/prepl}"]}
-
-  ;; End of Alternative REPL's
-  ;; ---------------------------------------------------
-
-  ;; ---------------------------------------------------
   ;; Creating projects from templates
 
   ;; clj-new - https://github.com/seancorfield/clj-new
@@ -354,7 +236,7 @@
   ;; clojure -M:project/new luminus practicalli/full-stack-app +http-kit +h2 +reagent +auth
 
   ;; Edn command line arguments
-  ;; clojure -X:project/new  ;; library project called playground
+  ;; clojure -X:project/new  ;; app project called playground
   ;; clojure -X:project/new :name practicalli/my-library
   ;; clojure -X:project/new :template app :name practicalli/my-application
   ;; clojure -X:project/new :template luminus :name practicalli/full-stack-app +http-kit +h2 +reagent +auth
@@ -365,30 +247,18 @@
    :exec-args    {:template app :name practicalli/playground}
    :main-opts    ["-m" "clj-new.create"]}
 
-  ;; ALPHA status: Add 'something' to existing project (subject to change)
-  :project/add
-  {:replace-deps {com.github.seancorfield/clj-new {:mvn/version "1.2.399"}}
-   :exec-fn      clj-new/generate
-   :main-opts    ["-m" "clj-new.generate"]}
-
   ;; clojure -T:project/create ; Create playground project using app template
   :project/create
   {:replace-deps {io.github.seancorfield/deps-new {:git/tag "v0.4.13" :git/sha "879c4eb"}}
    :exec-fn      org.corfield.new/create
    :exec-args    {:template app :name practicalli/playground}}
 
-  ;; to deprecate
-  :project/deps-new
-  {:replace-deps {io.github.seancorfield/deps-new {:git/tag "v0.4.13" :git/sha "879c4eb"}}
-   :exec-fn      org.corfield.new/create
-   :exec-args    {:template app :name practicalli/playground}}
-
-  ;; Convert Leiningen projects to Clojure CLI with depify
+;; Convert Leiningen projects to Clojure CLI with depify
   ;; Use `lein pprint` when `project.clj` includes quoted variables or paths to resolve
   ;; `lein pprint | clojure -M:project/depify`
   :project/depify
   {:extra-deps {depify/depify {:git/url "https://github.com/hagmonk/depify"
-                               :git/sha     "b3f61517c860518c1990133aa6eb54caf1e4d591"}}
+                               :git/sha "b3f61517c860518c1990133aa6eb54caf1e4d591"}}
    :main-opts  ["-m" "depify.project"]}
 
   ;; End of: Creating projects from templates
@@ -432,12 +302,7 @@
                    org.slf4j/slf4j-nop     {:mvn/version "2.0.5"}}
    :exec-fn antq.tool/outdated
    :exec-args {:directory ["."] ; default
-               :exclude ["com.cognitect/rebl"
-                         "org.openjfx/javafx-base"
-                         "org.openjfx/javafx-controls"
-                         "org.openjfx/javafx-fxml"
-                         "org.openjfx/javafx-swing"
-                         "org.openjfx/javafx-web"]
+               ;; :exclude ["com.cognitect/rebl"]
                ;; :focus ["com.github.liquidz/antq"]
                :skip ["boot" "leiningen"]
                :reporter "table" ; json edn format
@@ -445,20 +310,7 @@
                :upgrade false
                :force   false}}
 
-  :hack/antq
-  {:replace-deps
-   {antq/antq {:local/root "/home/practicalli/projects/clojure/community-tools/antq"}}
-   :main-opts ["-m" "antq.core"]}
-
-  ;; The classic project for checking maven based dependencies
-  ;; clojure -M:search/outdated-mvn
-  ;; DEPRECATE
-  :search/outdated-mvn
-  {:replace-paths []
-   :replace-deps  {deps-ancient/deps-ancient {:mvn/version "0.0.5"}}
-   :main-opts     ["-m" "deps-ancient.deps-ancient"]}
-
-  ;; Carve - search through code for unused vars and remove them
+;; Carve - search through code for unused vars and remove them
   ;; clojure -M:search/unused-vars --opts '{:paths ["src" "test"]}'
   :search/unused-vars
   {:extra-deps {borkdude/carve
@@ -466,67 +318,41 @@
                  :sha     "9c11e4727bff22386899f048d1d50b7978d3ac9e"}}
    :main-opts  ["-m" "carve.main"]}
 
-  ;; End of: Projects and dependencies
+  ;; End of Projects and dependencies
   ;; ---------------------------------------------------
 
   ;; ---------------------------------------------------
   ;; Project Packaging
-
-  ;; depstar - build jars, uberjars
-  ;; https://github.com/seancorfield/depstar
-  ;; over-ride the :main-class as the name is unlikely to match your project
-
-  ;; Jar archive of the project
-  ;; clojure -X:project/jar :main-class domain.application
-  ;; clojure -X:project/jar :jar '"project-name.jar"' :main-class domain.application
-  :project/jar
-  {:replace-deps {com.github.seancorfield/depstar {:mvn/version "2.1.303"}}
-   :exec-fn      hf.depstar/jar
-   :exec-args    {:jar "project.jar"
-                  :aot true}}
-
-  ;; Uberjar archive of the project, including Clojure runtime
-  ;; clojure -X:project/uberjar :main-class domain.application
-  ;; clojure -X:project/uberjar :jar '"project-name.jar"' :main-class domain.application
-  :project/uberjar
-  {:replace-deps {com.github.seancorfield/depstar {:mvn/version "2.1.303"}}
-   :exec-fn      hf.depstar/uberjar
-   :exec-args    {:jar "uber.jar"
-                  :aot true}}
+  ;; - use Clojure CLI tools.build approach
+  ;; https://practical.li/clojure/clojure-cli/projects/tools-build/
+  ;; https://clojure.org/guides/tools_build
 
   ;; End of project packaging
   ;; ---------------------------------------------------
 
   ;; ---------------------------------------------------
   ;; Project Deployment
-  ;; local and remote deployment of Java archives
 
-  ;; Clojure CLI tools - built in alias to deploy locally (in `~/.m2/`)
+  ;; Clojure CLI built-in alias to deploy locally (e.g. `~/.m2/`)
   ;; clojure -X:deps mvn-install
 
-  ;; deps-deploy - Deploy libraries to Clojars
-  ;; https://github.com/slipset/deps-deploy
+  ;; https://github.com/slipset/deps-deploy  - Deploy libraries to Clojars
+  ;; Set Clojars username/token in `CLOJARS_USERNAME` and `CLOJARS_PASSWORD` environment variables.
+  ;; Requires: fully qualified artifact-name and version in project `pom.xml` file
+
   ;; Deploy to Clojars
   ;; `clojure -M:project/clojars project.jar`
-  ;; Deploy to Clojars signed
-  ;; `clojure -M:project/clojars-signed project.jar`
-  ;;
-  ;; Set Clojars username/token in `CLOJARS_USERNAME` and `CLOJARS_PASSWORD`
-  ;; environment variables.
-  ;; Set fully qualified artifact-name and version in project `pom.xml` file
-
   :project/clojars
   {:replace-paths []
    :replace-deps  {slipset/deps-deploy {:mvn/version "0.2.0"}}
-   :main-opts     ["-m" "deps-deploy.deps-deploy"
-                   "deploy"]}
+   :main-opts     ["-m" "deps-deploy.deps-deploy" "deploy"]}
 
+  ;; Deploy to Clojars signed
+  ;; `clojure -M:project/clojars-signed project.jar`
   :project/clojars-signed
   {:replace-paths []
    :replace-deps  {slipset/deps-deploy {:mvn/version "0.2.0"}}
-   :main-opts     ["-m" "deps-deploy.deps-deploy"
-                   "deploy"
-                   :true]}
+   :main-opts     ["-m" "deps-deploy.deps-deploy" "deploy" :true]}
 
   ;; End of Project Deployment
   ;; ---------------------------------------------------
@@ -539,14 +365,6 @@
   ;; Examples are from Ubuntu package install locations
 
   ;; clojure -M:lib/java17-source
-  :src/java8
-  {:extra-deps
-   {openjdk/java-sources {:local/root "/usr/lib/jvm/openjdk-8/lib/src.zip"}}}
-
-  :src/java11
-  {:extra-deps
-   {openjdk/java-sources {:local/root "/usr/lib/jvm/openjdk-11/lib/src.zip"}}}
-
   :src/java17
   {:extra-deps
    {openjdk/java-sources {:local/root "/usr/lib/jvm/openjdk-17/lib/src.zip"}}}
@@ -556,6 +374,7 @@
   {:extra-paths ["src/jvm"]
    :extra-deps
    {org.clojure/clojure-source {:local/root "/home/practicalli/projects/community/clojure.org/clojure"}}}
+
   ;; End of: Java Sources
   ;; ---------------------------------------------------
 
@@ -581,18 +400,10 @@
                      :git/sha "14c18e5b593c39bc59f10df1b894c31a0020dc49"}}
    :main-opts ["-m" "cljstyle.main"]}
 
+  ;; clojure -M:format/cljfmt check | fix
   :format/cljfmt
   {:extra-deps {cljfmt/cljfmt {:mvn/version "0.9.0"}}
    :main-opts ["-m" "cljfmt.main"]}
-
-  :format/cljfmt-check
-  {:extra-deps {cljfmt/cljfmt {:mvn/version "0.9.0"}}
-   :main-opts ["-m" "cljfmt.main" "check"]}
-
-  ;; cljfmt-check - check/report formatting issues
-  :format/cljfmt-fix
-  {:extra-deps {cljfmt/cljfmt {:mvn/version "0.9.0"}}
-   :main-opts ["-m" "cljfmt.main" "fix"]}
 
   ;; End of: Formatting tools
   ;; ---------------------------------------------------
@@ -644,109 +455,6 @@
                 org.clojure/clojurescript {:mvn/version "1.10.844"}}
    :main-opts  ["-m" "cljs.main" "-re" "node"]}
 
-  ;; REBL Data browser - TO DEPRECATE
-  ;; https://github.com/practicalli/clojure-deps-edn#cognitect-rebl
-  ;; http://practicalli.github.io/clojure/alternative-tools/clojure-tools/cognitect-rebl.html
-  ;; Requires Clojure 1.10 or greater
-  ;; Requires Cognitect dev-tools https://cognitect.com/dev-tools/index.html
-  ;; :inspect/rebl-java8   (Oracle JDK 8 only)
-  ;; :inspect/rebl         (Any JDK 11 distribution - tested with OpenJDK)
-
-  ;; :inspect/rebl
-  ;; {:extra-deps {com.cognitect/rebl          {:mvn/version "0.9.241"}
-  ;;               org.clojure/core.async      {:mvn/version "1.3.618"}
-  ;;               org.openjfx/javafx-fxml     {:mvn/version "11.0.1"}
-  ;;               org.openjfx/javafx-controls {:mvn/version "11.0.1"}
-  ;;               org.openjfx/javafx-swing    {:mvn/version "11.0.1"}
-  ;;               org.openjfx/javafx-base     {:mvn/version "11.0.1"}
-  ;;               org.openjfx/javafx-web      {:mvn/version "11.0.1"}
-  ;;               ;; deps for file datafication (REBL 0.9.149 or later)
-  ;;               org.clojure/data.csv        {:mvn/version "1.0.0"}
-  ;;               org.clojure/data.json       {:mvn/version "2.4.0"}
-  ;;               org.yaml/snakeyaml          {:mvn/version "1.28"}}
-  ;;  :main-opts  ["-m" "cognitect.rebl"]}
-
-  ;; :inspect/rebl-java8
-  ;; {:extra-deps {com.cognitect/rebl {:mvn/version "0.9.241"}}
-  ;;  :main-opts  ["-m" "cognitect.rebl"]}
-
-  ;; Reveal - read evaluate visualize loop
-  ;; A REPL environment with data visualization and exploration
-  ;; http://practicalli.github.io/clojure/clojure-tools/data-browsers/reveal.html
-  ;; clojure -X:inspect/reveal
-  ;; Run with theme / font changes:
-  ;; clojure -X:inspect/reveal-light
-  ;; Use with rebel repl by adding and using tap>
-  ;; clojure -M:inspect/reveal-rebel
-  ;; clojure -M:inspect/reveal:rebel -J-Dvlaaad.reveal.prefs='{:theme :light :font-family "Ubuntu Mono" :font-size 32}'
-
-  :inspect/reveal
-  {:extra-deps {vlaaad/reveal {:mvn/version "1.3.276"}}
-   :exec-fn    vlaaad.reveal/repl
-   :main-opts  ["-m" "vlaaad.reveal" "repl"]}
-
-  :inspect/reveal-light
-  {:extra-deps {vlaaad/reveal {:mvn/version "1.3.276"}}
-   :exec-fn    vlaaad.reveal/repl
-   :jvm-opts   ["-Dvlaaad.reveal.prefs={:theme,:light,:font-family,\"https://ff.static.1001fonts.net/u/b/ubuntu.mono.ttf\",:font-size,32}"]
-   :main-opts  ["-m" "vlaaad.reveal" "repl"]}
-
-  ;; Not sending all evaluations to Reveal
-  ;; It does send tap> results to Reveal
-  ;; :repl/reveal-rebel-nrepl
-  ;; {:extra-deps {nrepl/nrepl                {:mvn/version "0.9.0"}
-  ;;               cider/cider-nrepl          {:mvn/version "0.28.7"}
-  ;;               vlaaad/reveal              {:mvn/version "1.3.276"}
-  ;;               com.bhauman/rebel-readline {:mvn/version "0.1.4"}}
-  ;;  :jvm-opts   ["-Dvlaaad.reveal.prefs={:theme,:light,:font-family,\"https://ff.static.1001fonts.net/u/b/ubuntu.mono.ttf\",:font-size,32}"]
-  ;;  :main-opts  ["-m" "nrepl.cmdline"
-  ;;               "--middleware" "[cider.nrepl/cider-middleware,vlaaad.reveal.nrepl/middleware]"
-  ;;               "-f" "rebel-readline.main/-main"]}
-
-  :inspect/reveal-local ; Hacking the project
-  {:extra-deps {vlaaad/reveal
-                {:local/root "/home/practicalli/projects/clojure/visualization/reveal/"}}
-   :main-opts  ["-m" "vlaaad.reveal" "repl"]}
-
-  ;; Reveal with Clojure editors
-  ;; clj -M:inspect/reveal-nrepl
-  ;; add the -i flag for interactive REPL client
-  ;; Reveal REPL with nrepl server, connect to from a Clojure aware editor
-  :inspect/reveal-nrepl
-  {:extra-deps {vlaaad/reveal {:mvn/version "1.3.276"}
-                nrepl/nrepl   {:mvn/version "1.0.0"}}
-   :main-opts  ["-m" "nrepl.cmdline"
-                "--middleware" "[vlaaad.reveal.nrepl/middleware]"]}
-
-  ;; Light version of :inspect/reveal-nrepl
-  :inspect/reveal-light-nrepl
-  {:extra-deps {vlaaad/reveal {:mvn/version "1.3.276"}
-                nrepl/nrepl   {:mvn/version "1.0.0"}}
-   :jvm-opts   ["-Dvlaaad.reveal.prefs={:theme,:light,:font-family,\"https://ff.static.1001fonts.net/u/b/ubuntu.mono.ttf\",:font-size,32}"]
-   :main-opts  ["-m" "nrepl.cmdline"
-                "--middleware" "[vlaaad.reveal.nrepl/middleware]"]}
-
-  ;; Reveal with headless nrepl server and Emacs CIDER specific middleware
-  ;; Use with `C-u cider-jack-in-clj` or `SPC u , '` on Spacemacs
-  ;; Edit jack-in command: clojure -M:inspect/reveal-nrepl-cider
-  :inspect/reveal-cider
-  {:extra-deps {vlaaad/reveal                 {:mvn/version "1.3.276"}
-                nrepl/nrepl                   {:mvn/version "1.0.0"}
-                cider/cider-nrepl             {:mvn/version "0.28.7"}
-                refactor-nrepl/refactor-nrepl {:mvn/version "3.6.0"}}
-   :main-opts  ["-m" "nrepl.cmdline"
-                "--middleware" "[vlaaad.reveal.nrepl/middleware,refactor-nrepl.middleware/wrap-refactor,cider.nrepl/cider-middleware]"]}
-
-  ;; Light version of :inspect/reveal-nrepl-cider
-  :inspect/reveal-light-cider
-  {:extra-deps {vlaaad/reveal                 {:mvn/version "1.3.276"}
-                nrepl/nrepl                   {:mvn/version "1.0.0"}
-                cider/cider-nrepl             {:mvn/version "0.28.7"}
-                refactor-nrepl/refactor-nrepl {:mvn/version "3.6.0"}}
-   :jvm-opts   ["-Dvlaaad.reveal.prefs={:theme,:light,:font-family,\"https://ff.static.1001fonts.net/u/b/ubuntu.mono.ttf\",:font-size,32}"]
-   :main-opts  ["-m" "nrepl.cmdline"
-                "--middleware" "[vlaaad.reveal.nrepl/middleware,refactor-nrepl.middleware/wrap-refactor,cider.nrepl/cider-middleware]"]}
-
   ;; End of Data inspectors
   ;; ---------------------------------------------------
 
@@ -770,54 +478,10 @@
   ;; - start a non-interactive REPL with a headless nREPL server
   ;; clojure -M:middleware/nrepl
   :middleware/nrepl
-  {:extra-deps {nrepl/nrepl {:mvn/version "1.0.0"}}
-   :main-opts  ["-m" "nrepl.cmdline"]}
-
-  ;; Run a REPL using nREPL server for access by cider-connect-clj
-  ;; clojure -M:middleware/cider-clj
-  :middleware/cider-clj
-  {:extra-deps {nrepl/nrepl       {:mvn/version "1.0.0"}
+  {:extra-deps {nrepl/nrepl {:mvn/version "1.0.0"}
                 cider/cider-nrepl {:mvn/version "0.28.7"}}
    :main-opts  ["-m" "nrepl.cmdline"
                 "--middleware" "[cider.nrepl/cider-middleware]"]}
-
-  :middleware/cider-clj-refactor
-  {:extra-deps {nrepl/nrepl                   {:mvn/version "1.0.0"}
-                refactor-nrepl/refactor-nrepl {:mvn/version "3.6.0"}
-                cider/cider-nrepl             {:mvn/version "0.28.7"}}
-   :main-opts  ["-m" "nrepl.cmdline"
-                "--middleware" "[refactor-nrepl.middleware/wrap-refactor,cider.nrepl/cider-middleware]"]}
-
-  ;; Run a REPL using nREPL server for access by cider-connect-cljs
-  ;; clojure -M:middleware/cider-cljs
-  ;; Using figwheel-main template and cider-connect-cljs: clojure -M:middleware/cider-cljs:fig
-  :middleware/cider-cljs
-  {:extra-deps {org.clojure/clojurescript {:mvn/version "1.10.844"}
-                nrepl/nrepl               {:mvn/version "1.0.0"}
-                cider/cider-nrepl         {:mvn/version "0.28.7"}
-                cider/piggieback          {:mvn/version "0.5.3"}}
-   :main-opts  ["-m" "nrepl.cmdline"
-                "--middleware" "[cider.nrepl/cider-middleware,cider.piggieback/wrap-cljs-repl]"]}
-
-  ;; nrebl.middleware - REBL with nREPL server
-  ;; visualize evaluations over nREPL in REBL data browser (CIDER, Calva)
-  ;; https://github.com/RickMoynihan/nrebl.middleware
-  ;; Emacs cider `dir-locals.el` configuration
-  ;; ((clojure-mode . ((cider-clojure-cli-global-options . "-M:lib/cider-nrepl:inspect/rebl:middleware/nrebl"))))
-
-  ;; clojure -M:lib/cider-nrepl:inspect/rebl:middleware/nrebl
-  :middleware/nrebl
-  {:extra-deps {rickmoynihan/nrebl.middleware {:mvn/version "0.3.1"}}
-   :main-opts  ["-e" "((requiring-resolve,'cognitect.rebl/ui))"
-                "-m" "nrepl.cmdline"
-                "--interactive"
-                "--middleware" "[nrebl.middleware/wrap-nrebl,cider.nrepl/cider-middleware]"]}
-
-  ;; Supporting aliases for nrebl.middleware
-  :lib/cider-nrepl
-  {:extra-deps {nrepl/nrepl                   {:mvn/version "1.0.0"}
-                cider/cider-nrepl             {:mvn/version "0.28.7"}
-                refactor-nrepl/refactor-nrepl {:mvn/version "3.6.0"}}}
 
   ;; End of: Middleware
   ;; ---------------------------------------------------
@@ -843,7 +507,7 @@
   ;; ---------------------------------------------------
 
   ;; ---------------------------------------------------
-  ;; Testing frameworks
+  ;; Testing Environment / Libraries
 
   ;; Include the test directory on the class path
   ;; Humane test output for pretty printed results
@@ -855,19 +519,7 @@
   :lib/ring-mock
   {:extra-deps {ring/ring-mock         {:mvn/version "0.4.0"}}}
 
-  ;; Expectations test framework
-  ;; https://github.com/clojure-expectations/clojure-test
-  ;; Example usage:
-  ;; clojure -A:expectations:test/cognitect
-  :lib/expectations
-  {:extra-deps {expectations/clojure-test {:mvn/version "1.2.1"}}}
-
-  ;; Classic version not compatible with clojure.test and tools
-  ;; https://github.com/clojure-expectations/expectations
-  :lib/expectations-classic
-  {:extra-deps {expectations/expectations {:mvn/version "2.1.10"}}}
-
-  ;; End of: Testing frameworks
+  ;; End of Testing frameworks
   ;; ---------------------------------------------------
 
   ;; ---------------------------------------------------
@@ -915,33 +567,7 @@
                :randomize? false
                :fail-fast? true}}
 
-  ;; Experiment: test using alternative configuration
-  :test/kaocha-global
-  {:extra-paths ["test"]
-   :extra-deps {lambdaisland/kaocha {:mvn/version "1.71.1119"}}
-   :exec-fn kaocha.runner/exec-fn
-   :exec-args {:config-file ["~/.clojure/kaocha-global-tests.edn"]}}
-
-  ;; clojure -X:test/kaocha
-  :test/kaocha
-  {:extra-paths ["test"]
-   :extra-deps {lambdaisland/kaocha {:mvn/version "1.71.1119"}}
-   :main-opts   ["-m" "kaocha.runner"]
-   :exec-fn kaocha.runner/exec-fn
-   :exec-args {}}
-
-  ;; clojure -X:test/kaocha-watch
-  :test/kaocha-watch
-  {:extra-paths ["test"]
-   :extra-deps  {lambdaisland/kaocha {:mvn/version "1.71.1119"}}
-   :main-opts   ["-m" "kaocha.runner" "--watch" "--fail-fast" "--skip-meta" ":slow"]
-   :exec-fn kaocha.runner/exec-fn
-   :exec-args {:watch? true
-               :randomize? false
-               :fail-fast? true}}
-
-  ;; clojure -M:test/kaocha-cljs
-  :test/kaocha-cljs
+  :test/test-cljs
   {:extra-paths ["test"]
    :extra-deps  {lambdaisland/kaocha      {:mvn/version "1.71.1119"}
                  lambdaisland/kaocha-cljs {:mvn/version "1.4.130"}}
@@ -1133,58 +759,51 @@
   ;; End of Security
   ;; ---------------------------------------------------
 
+;; ---------------------------------------------------
+  ;; Alternative REPLs - not extensively tested
+
+  ;; Clojure Socket REPL on port 55555:
+  ;; clojure -X:repl/socket
+  :repl/socket
+  {:exec-fn clojure.core.server/start-server
+   :exec-args {:name "repl-server"
+               :port 55555
+               :accept clojure.core.server/repl
+               :server-daemon false}}
+
+  ;; Older Socket REPL approaches to review:
+
+  ;; clojure -M:repl/socket-jvm-opts (lesser used approach)
+  :repl/socket-jvm-opts
+  {:jvm-opts ["-Dclojure.server.repl={:port,50505,:accept,clojure.core.server/repl}"]}
+
+  ;; Clojure Socket REPL on an available port, displaying port number (container/cloud environments)
+  ;; - specify -r to start a repl
+  :repl/socket-zero
+  {:jvm-opts  ["-Dclojure.server.repl={:port,0,:accept,clojure.core.server/repl}"]
+   :main-opts ["-e" "(.getLocalPort,(get-in,@#'clojure.core.server/servers,[\"repl\",:socket]))"]}
+
+  ;; ClojureScript (node) Socket REPL on port 55555:
+  ;; clojure -M:repl/socket-cljs
+  :repl/socket-node
+  {:jvm-opts ["-Dclojure.server.repl={:port,55555,:accept,cljs.server.node/repl}"]}
+
+  ;; ClojureScript (browser) Socket REPL on port 58585:
+  ;; clojure -M:repl/socket-cljs
+  :repl/socket-browser
+  {:jvm-opts ["-Dclojure.server.repl={:port,58585,:accept,cljs.server.browser/repl}"]}
+
+  ;; tubular - socket repl client
+  ;; https://github.com/mfikes/tubular
+  ;; Connect to a socket repl, e.g. :repl/socket
+  ;; clojure -M:repl/socket-client
+  :repl/socket-client
+  {:extra-deps {tubular/tubular {:mvn/version "1.4.0"}}
+   :main-opts  ["-m" "tubular.core"
+                "-p" "55555"]}
+
+;; End of Alternative REPL's
   ;; ---------------------------------------------------
-  ;; Deprecated
-
-  ;; midje-runner
-  ;; https://github.com/miorimmax/midje-runner
-  :test/midje
-  {:extra-paths ["test"]
-   :extra-deps  {midge-runner/midje-runner
-                 {:git/url "https://github.com/miorimmax/midje-runner.git"
-                  :sha     "ee9c2813e150ae6b3ea41b446b09ba40fc89bdc1"}}
-   :main-opts   ["-m" "midje-runner.runner"]}
-
-  ;; uberdeps - https://github.com/tonsky/uberdeps
-  ;; recommend depstar until that is migrated into tools.build
-  :project/uberdeps
-  {:replace-paths []
-   :replace-deps  {uberdeps/uberdeps {:mvn/version "1.1.4"}}
-   :main-opts     ["-m" "uberdeps.uberjar"]}
-
-  ;; End of Deprecated
-  ;; ---------------------------------------------------
-
-  ;; ---------------------------------------------------
-  ;; ---------------------------------------------------
-  ;; EXPERIMENTAL - use at your own risk, you have been warned
-
-  ;; ---------------------------------------------------
-  ;; Hot loading dependencies - EXPERIMENTAL / APLPHA
-  ;; ---------------------------------------------------
-  ;; Hot loading is not officially part of tools.deps and could change in future
-  ;; https://practical.li/clojure/alternative-tools/clojure-tools/hotload-libraries.html
-
-  ;; Add new deps to a running REPL:
-  ;; (require '[clojure.tools.deps.alpha.repl :refer [add-libs]])
-  ;; (add-libs 'domain/library {:mvn/version "1.0.1"})
-  ;; Git deps
-  ;; (require '[clojure.tools.gitlibs :as gitlibs])
-  ;; (defn load-master [lib]
-  ;;   (let [git (str "https://github.com/" lib ".git")]
-  ;;    (add-lib lib {:git/url git :sha (gitlibs/resolve git "master")})))
-  ;; - e.g., using the GitHub path (not the usual Maven group/artifact):
-  ;; (load-master 'clojure/tools.trace)
-
-  :alpha/hotload-socket
-  {:extra-deps {org.clojure/tools.deps.alpha
-                ;; Latest commit on add-lib3 branch, don't update with :search/outdated
-                {:git/url "https://github.com/clojure/tools.deps.alpha"
-                 :sha     "e4fb92eef724fa39e29b39cc2b1a850567d490dd"}
-                ;; Set logging implementation to no-operation
-                org.slf4j/slf4j-nop {:mvn/version "2.0.5"}}
-   ;; DynamicClassLoader required when starting other processes via aliases, e.g. socket REPL or Cognitect's REBL
-   :main-opts  ["-e" "(->>(Thread/currentThread)(.getContextClassLoader)(clojure.lang.DynamicClassLoader.)(.setContextClassLoader,(Thread/currentThread)))"]}
 
   ;; ---------------------------------------------------
   ;; Aliases to evaluate

--- a/deps.edn
+++ b/deps.edn
@@ -79,13 +79,14 @@
   :env/dev
   {:extra-paths ["dev"]}
 
-  :dev/reloaded
+  :env/reloaded
   {:extra-paths ["dev" "test"]
    :extra-deps  {djblue/portal {:mvn/version "0.34.2"}
                  org.clojure/tools.namespace {:mvn/version "1.3.0"}
                  org.clojure/tools.deps.alpha {:git/url "https://github.com/clojure/tools.deps.alpha"
                                                :git/sha "e4fb92eef724fa39e29b39cc2b1a850567d490dd"}
                  org.slf4j/slf4j-nop {:mvn/version "2.0.5"}
+                 lambdaisland/kaocha {:mvn/version "1.71.1119"}
                  org.clojure/test.check {:mvn/version "1.1.1"}
                  ring/ring-mock         {:mvn/version "0.4.0"}}}
 
@@ -129,17 +130,8 @@
   ;; ---------------------------------------------------
   ;; Running a REPL
 
-  ;; Simple nREPL server REPL, headless
-  ;; call with -i flag to start interactive client
-  :repl/nrepl
-  {:extra-deps {nrepl/nrepl {:mvn/version "1.0.0"}
-                cider/cider-nrepl {:mvn/version "0.28.7"}}
-   :main-opts  ["-m" "nrepl.cmdline"
-                "--middleware" "[cider.nrepl/cider-middleware]"
-                "--interactive"]}
-
   ;; Interactive client REPL with nREPL server for Clojure Editor support
-  :repl/interactive
+  :repl/basic
   {:extra-deps {nrepl/nrepl {:mvn/version "1.0.0"}
                 cider/cider-nrepl {:mvn/version "0.28.7"}}
    :main-opts  ["-m" "nrepl.cmdline"
@@ -161,7 +153,7 @@
                 "--middleware" "[refactor-nrepl.middleware/wrap-refactor,cider.nrepl/cider-middleware]"
                 "--interactive"]}
 
-  ;; clojure -M:repl/cider-cljs
+  ;; clojure -M:repl/cljs
   :repl/cljs
   {:extra-deps {org.clojure/clojurescript       {:mvn/version "1.10.773"}
                 nrepl/nrepl                     {:mvn/version "1.0.0"}
@@ -209,6 +201,7 @@
                 org.clojure/tools.deps.alpha {:git/url "https://github.com/clojure/tools.deps.alpha"
                                               :git/sha "e4fb92eef724fa39e29b39cc2b1a850567d490dd"}
                 org.slf4j/slf4j-nop {:mvn/version "2.0.5"}
+                lambdaisland/kaocha {:mvn/version "1.71.1119"}
                 org.clojure/test.check {:mvn/version "1.1.1"}
                 ring/ring-mock         {:mvn/version "0.4.0"}}
    :main-opts  ["-m" "nrepl.cmdline"
@@ -499,20 +492,6 @@
   ;; ---------------------------------------------------
 
   ;; ---------------------------------------------------
-  ;; Middleware
-
-  ;; - start a non-interactive REPL with a headless nREPL server
-  ;; clojure -M:middleware/nrepl
-  :middleware/nrepl
-  {:extra-deps {nrepl/nrepl {:mvn/version "1.0.0"}
-                cider/cider-nrepl {:mvn/version "0.28.7"}}
-   :main-opts  ["-m" "nrepl.cmdline"
-                "--middleware" "[cider.nrepl/cider-middleware]"]}
-
-  ;; End of: Middleware
-  ;; ---------------------------------------------------
-
-  ;; ---------------------------------------------------
   ;; Clojure Specifications
 
   ;; Clojure spec test.check (clojure spec included in Clojure 1.9 onwards)
@@ -561,14 +540,7 @@
    :main-opts   ["-m" "cognitect.test-runner"]
    :exec-fn cognitect.test-runner.api/test}
 
-  ;; ClojureScript test runner
-  ;; https://github.com/Olical/cljs-test-runner
-  :test/cljs
-  {:extra-paths ["test"]
-   :extra-deps  {olical/cljs-test-runner {:mvn/version "3.8.0"}}
-   :main-opts   ["-m" "cljs-test-runner.main"]}
-
-  ;; kaocha - comprehensive test runner for Clojure/Script
+;; kaocha - comprehensive test runner for Clojure/Script
   ;; tests.edn should be created for each project
   ;; https://github.com/lambdaisland/kaocha
 
@@ -593,7 +565,7 @@
                :randomize? false
                :fail-fast? true}}
 
-  :test/test-cljs
+  :test/cljs
   {:extra-paths ["test"]
    :extra-deps  {lambdaisland/kaocha      {:mvn/version "1.71.1119"}
                  lambdaisland/kaocha-cljs {:mvn/version "1.4.130"}}
@@ -785,8 +757,8 @@
   ;; End of Security
   ;; ---------------------------------------------------
 
-;; ---------------------------------------------------
-  ;; Alternative REPLs - not extensively tested
+  ;; ---------------------------------------------------
+  ;; Socket REPL
 
   ;; Clojure Socket REPL on port 55555:
   ;; clojure -X:repl/socket
@@ -828,7 +800,7 @@
    :main-opts  ["-m" "tubular.core"
                 "-p" "55555"]}
 
-;; End of Alternative REPL's
+  ;; End of Socket REPL
   ;; ---------------------------------------------------
 
   ;; ---------------------------------------------------


### PR DESCRIPTION
Simplify the `deps.edn` configuration by moving alias definitions that are deprecated or unused to `deps-deprecated.edm`

Resolve #60 

## Deprecated projects
- `:project/jar` & `:project/uberjar` - tools.build is recommended approach


## Covered by other aliases
- `:repl/cider` - covered by `repl/interactive` or `repl/rebel` (with rebel UI)
- `:format/cljfmt-check` and `:format/cljfmt-fix` - covered by `:format/cljfmt check | fix`
- `:test/kaocha`, `:test/kaocha-global`, `:test/kaocha-watch`, `:test/kaocha-cljs` - covered by `:test/run`, `:test/watch`
 

## Simplified aliases
- `search/outdated` contains excludes added for the deprecated Congnitect REBL aliases


## Never used
- `:repl/prepl` and `:repl/prepl-cljs`
- `:hack/antq` - used once to fix an issue in antq
- `repl/rebel-reveal`, `repl/rebel-reveal-light`, `inspect/reveal`, `inspect/reveal-light`, `inspect/reveal-local`, `inspect/reveal-nrepl`, `inspect/reveal-nrepl-light`, `inspect/reveal-cider`, `inspect/reveal-cider-light` - portal used rather than semi-commercial reveal
- `middleware/cider-clj`, `middleware/cider-clj-refactor`, `middleware/cider-cljs`, `middleware/nrebel`, `:lib/cider-nrepl`
- `:lib/expectations`, `:lib/expectations-classic`
- `:test/midje`
- `:project/uberdeps`
- `alpha/hotload-sockets`

## Not operational
- `:repl/rebel-figwheel` - not working correctly
