### PR TITLE
alias: sayid aliases that include middleware

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,6 +1,11 @@
 #+TITLE: Changelog
 
 * Unreleased
+** Changed
+*** Correct libspec for kaocha test runner (change back to strings)
+*** Add sayid related aliases with middleware `:repl/debug`, `:repl/debug-refactor`, `:repl/rebel-debug`, `:repl/rebel-debug-refactor`
+*** Deprecate `:lib/sayid` as middleware should be included for sayid to function correctly with Clojure CLI
+
 
 * 2023-02-21
 ** Added

--- a/README.md
+++ b/README.md
@@ -417,9 +417,12 @@ Emacs CIDER has a built in debug tool that requires no dependencies (other than 
 
 [Sayid](https://github.com/clojure-emacs/sayid) is a comprehensive debug and profile tool (which requires your code to compile) and generated a full and detailed history of an evaluation.
 
-* `lib/sayid` -  an omniscient debugger and profiler for Clojure
+* `:repl/debug` run basic REPL prompt with sayid, and cider-nrepl middleware
+* `:repl/debug-refactor` run basic REPL prompt with sayid, clj-refactor and cider-nrepl middleware
+* `:repl/rebel-debug` run Rebel rich UI REPL prompt with sayid, and cider-nrepl middleware
+* `:repl/rebel-debug-refactor` run Rebel rich UI REPL prompt with sayid, clj-refactor and cider-nrepl middleware
 
-The `:lib/sayid` alias can be used with `:repl/cider` when using `cider-connect-clj` or added to the `cider-jack-in-clj` command manually, or via a `.dir-locals.el` configuration using `cider-clojure-cli-aliases`. See the [Practicalli Spacemacs project configuration guide](https://practical.li/spacemacs/clojure-development/project-configuration/) for examples.
+[Practicalli Spacemacs - Sayid debug and profile tool](https://practical.li/spacemacs/debug-clojure/sayid-debug/) covers the use of these aliases in more detail
 
 
 ## Clojure Specification

--- a/deps-deprecated.edn
+++ b/deps-deprecated.edn
@@ -401,6 +401,14 @@
   ;; End of Test runners
   ;; ---------------------------------------------------
 
+  ;; ---------------------------------------------------
+  ;; Debug
+  ;; DEPRECATED - requires middleware to be useful
+  :lib/sayid
+  {:extra-deps {com.billpiel/sayid {:mvn/version "0.1.0"}}}
+
+  ;; ---------------------------------------------------
+
   ;; midje-runner
   ;; https://github.com/miorimmax/midje-runner
   :test/midje

--- a/deps.edn
+++ b/deps.edn
@@ -155,6 +155,23 @@
                 "--middleware" "[refactor-nrepl.middleware/wrap-refactor,cider.nrepl/cider-middleware]"
                 "--interactive"]}
 
+  :repl/debug
+  {:extra-deps {nrepl/nrepl        {:mvn/version "0.9.0"}
+                com.billpiel/sayid {:mvn/version "0.1.0"}
+                cider/cider-nrepl  {:mvn/version "0.28.5"}}
+   :main-opts  ["-m" "nrepl.cmdline"
+                "--middleware" "[com.billpiel.sayid.nrepl-middleware/wrap-sayid,cider.nrepl/cider-middleware]"
+                "--interactive"]}
+
+  :repl/debug-refactor
+  {:extra-deps {nrepl/nrepl                   {:mvn/version "0.9.0"}
+                cider/cider-nrepl             {:mvn/version "0.28.5"}
+                refactor-nrepl/refactor-nrepl {:mvn/version "3.5.3"}
+                com.billpiel/sayid            {:mvn/version "0.1.0"}}
+   :main-opts  ["-m" "nrepl.cmdline"
+                "--middleware" "[com.billpiel.sayid.nrepl-middleware/wrap-sayid,refactor-nrepl.middleware/wrap-refactor,cider.nrepl/cider-middleware]"
+                "--interactive"]}
+
   ;; clojure -M:repl/cljs
   :repl/cljs
   {:extra-deps {org.clojure/clojurescript       {:mvn/version "1.10.773"}
@@ -209,6 +226,27 @@
                 ring/ring-mock         {:mvn/version "0.4.0"}}
    :main-opts  ["-m" "nrepl.cmdline"
                 "--middleware" "[cider.nrepl/cider-middleware]"
+                "--interactive"
+                "-f" "rebel-readline.main/-main"]}
+
+  :repl/rebel-debug
+  {:extra-deps {nrepl/nrepl                {:mvn/version "0.9.0"}
+                cider/cider-nrepl          {:mvn/version "0.28.5"}
+                com.billpiel/sayid         {:mvn/version "0.1.0"}
+                com.bhauman/rebel-readline {:mvn/version "0.1.4"}}
+   :main-opts  ["-m" "nrepl.cmdline"
+                "--middleware" "[com.billpiel.sayid.nrepl-middleware/wrap-sayid,cider.nrepl/cider-middleware]"
+                "--interactive"
+                "-f" "rebel-readline.main/-main"]}
+
+  :repl/rebel-debug-refactor
+  {:extra-deps {nrepl/nrepl                   {:mvn/version "0.9.0"}
+                cider/cider-nrepl             {:mvn/version "0.28.5"}
+                refactor-nrepl/refactor-nrepl {:mvn/version "3.5.3"}
+                com.billpiel/sayid            {:mvn/version "0.1.0"}
+                com.bhauman/rebel-readline {:mvn/version "0.1.4"}}
+   :main-opts  ["-m" "nrepl.cmdline"
+                "--middleware" "[com.billpiel.sayid.nrepl-middleware/wrap-sayid,refactor-nrepl.middleware/wrap-refactor,cider.nrepl/cider-middleware]"
                 "--interactive"
                 "-f" "rebel-readline.main/-main"]}
 
@@ -514,9 +552,6 @@
 
   ;; ---------------------------------------------------
   ;; Debug Tools
-
-  :lib/sayid
-  {:extra-deps {com.billpiel/sayid {:mvn/version "0.1.0"}}}
 
   ;; https://github.com/vvvvalvalval/scope-capture
   ;; save and restore the local environment


### PR DESCRIPTION
sayid requires middleware to function correctly with Clojure CLI,
including the library as a dependency alone is not enough

Add the following alias definitions to support sayid
- `:repl/debug` run basic REPL prompt with sayid, and cider-nrepl middleware
- `:repl/debug-refactor` run basic REPL prompt with sayid, clj-refactor and cider-nrepl middleware
- `:repl/rebel-debug` run Rebel rich UI REPL prompt with sayid, and cider-nrepl middleware
- `:repl/rebel-debug-refactor` run Rebel rich UI REPL prompt with sayid, clj-refactor and cider-nrepl middleware

[Related: clojure-emacs/sayid/issues/35 & practicalli/spacemacs/issues/325]
[Resolve: #62]